### PR TITLE
Add the otherPlayer turn update methods and fix some bugs

### DIFF
--- a/src/main/Advisor.py
+++ b/src/main/Advisor.py
@@ -11,7 +11,7 @@ from agentAIUtils import myself_turn_players_update
 from agentAIUtils import secret_infer_helper
 from agentAIUtils import otherAgent_infer_helper
 from agentAIUtils import otherAgent_turnUpdate_3cardsCase
-
+from agentAIUtils import otherAgent_turnUpdate_0cardsCase
 
 
 
@@ -100,7 +100,7 @@ class Advisor:
         oppoQuery_suspect, oppoQuery_weapon, oppoQuery_room = oppoQuery.split(",")[0].strip(), oppoQuery.split(",")[1].strip(), oppoQuery.split(",")[2].strip()
         
         cardGivers = input("Player(s) who give a card(including yourself, Enter None if no ones) : ")
-        cardGivers_list = [x.strip() for x in cardGivers.split(",")]
+        cardGivers_list = [] if cardGivers == "None" else [x.strip() for x in cardGivers.split(",")]
         cardNumber = 0 if cardGivers == "None" else len(cardGivers_list)
 
         self.udpate_log(whose_turn, oppoQuery_suspect, oppoQuery_weapon, oppoQuery_room, cardNumber, cardGivers_list)
@@ -325,7 +325,7 @@ class Advisor:
         elif cards_received == 1:
             pass
         elif cards_received == 0:
-            pass
+            otherAgent_turnUpdate_0cardsCase(player_makeQuery, claim_suspect, claim_weapon, claim_room, self.players)
 
 
 

--- a/src/main/Advisor.py
+++ b/src/main/Advisor.py
@@ -10,6 +10,7 @@ from agentAIUtils import search_in_must_have
 from agentAIUtils import myself_turn_players_update
 from agentAIUtils import secret_infer_helper
 from agentAIUtils import otherAgent_infer_helper
+from agentAIUtils import otherAgent_turnUpdate_3cardsCase
 
 
 
@@ -53,7 +54,7 @@ class Advisor:
                     #break
                 elif whose_turn in self.players:
                     self.update_oppoTurn(whose_turn)
-                    #self.AI_unit_otherTurn_update()
+                    self.AI_unit_otherTurn_update()
                     #break
                 else:
                     print("Wrong name, enter again: ")
@@ -318,6 +319,10 @@ class Advisor:
         card_givers = self.log.iloc[-1,:]["card_giver(s)"]
 
         if cards_received == 3:
+            otherAgent_turnUpdate_3cardsCase(player_makeQuery, claim_suspect, claim_weapon, claim_room, card_givers, self.players)
+        elif cards_received == 2:
+            pass
+        elif cards_received == 1:
             pass
         elif cards_received == 0:
             pass

--- a/src/main/Advisor.py
+++ b/src/main/Advisor.py
@@ -6,14 +6,8 @@ import pandas as pd
 
 import sys
 sys.path.append("../utils/")
-from agentAIUtils import search_in_must_have
-from agentAIUtils import myself_turn_players_update
-from agentAIUtils import secret_infer_helper
-from agentAIUtils import otherAgent_infer_helper
-from agentAIUtils import otherAgent_turnUpdate_3cardsCase
-from agentAIUtils import otherAgent_turnUpdate_0cardsCase
+from agentAIUtils import search_in_must_have, myself_turn_players_update, secret_infer_helper, otherAgent_infer_helper, otherAgent_turnUpdate_3cardsCase, otherAgent_turnUpdate_1cardsCase, otherAgent_turnUpdate_0cardsCase
 
-# CONSTANTS in Advisor class, _config
 global Total_Number_of_Card, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM
 Total_Number_of_Card = 30
 LIST_SUSPECT = ["Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Colonel Mustard", "Professor Plum", "Miss Peach", "Sgt. Gray", "Monsieur Brunette", "Mme. Rose"]
@@ -323,7 +317,7 @@ class Advisor:
         elif cards_received == 2:
             pass
         elif cards_received == 1:
-            pass
+            otherAgent_turnUpdate_1cardsCase(player_makeQuery, claim_suspect, claim_weapon, claim_room, card_givers, self.players)
         elif cards_received == 0:
             otherAgent_turnUpdate_0cardsCase(player_makeQuery, claim_suspect, claim_weapon, claim_room, self.players)
 

--- a/src/main/Advisor.py
+++ b/src/main/Advisor.py
@@ -248,12 +248,6 @@ class Advisor:
 
     def player_summary(self, player_name):
         print(player_name)
-        print("\n suspect must have:  ")
-        self.players[player_name].display_suspect_must_have()
-        print("\n weapon must have:  ")
-        self.players[player_name].display_weapon_must_have()
-        print("\n room must have:  ")
-        self.players[player_name].display_room_must_have()
         
         if player_name != "secret":
             print("\n Base Value: ", self.players[player_name].base_value_general)
@@ -262,18 +256,27 @@ class Advisor:
             print("\n Weapon Base Value: ", self.players[player_name].base_value_secret_weapon)
             print("\n Room Base Value: ", self.players[player_name].base_value_secret_room)
         
+        print("\n suspect must have:  ")
+        self.players[player_name].display_suspect_must_have()
         print("\n suspect probably have:  ")
         self.players[player_name].display_suspect_possibly_have()
-        print("\n weapon probably have:  ")
-        self.players[player_name].display_weapon_possibly_have()
-        print("\n room probably have:  ")
-        self.players[player_name].display_room_possibly_have()
         print("\n suspect must not have:  ")
         self.players[player_name].display_suspect_must_not_have()
+
+        print("\n weapon must have:  ")
+        self.players[player_name].display_weapon_must_have()
+        print("\n weapon probably have:  ")
+        self.players[player_name].display_weapon_possibly_have()
         print("\n weapon must not have:  ")
         self.players[player_name].display_weapon_must_not_have()
+        
+        print("\n room must have:  ")
+        self.players[player_name].display_room_must_have()
+        print("\n room probably have:  ")
+        self.players[player_name].display_room_possibly_have()
         print("\n room must not have:  ")
         self.players[player_name].display_room_must_not_have()
+
 
 
     def display_log(self):

--- a/src/main/Advisor.py
+++ b/src/main/Advisor.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 import sys
 sys.path.append("../utils/")
-from agentAIUtils import search_in_must_have, myself_turn_players_update, secret_infer_helper, otherAgent_infer_helper, otherAgent_turnUpdate_3cardsCase, otherAgent_turnUpdate_1cardsCase, otherAgent_turnUpdate_0cardsCase
+from agentAIUtils import search_in_must_have, myself_turn_players_update, secret_infer_helper, otherAgent_infer_helper, otherAgent_turnUpdate_3cardsCase, otherAgent_turnUpdate_OneTwo_cardsCase, otherAgent_turnUpdate_0cardsCase
 
 global Total_Number_of_Card, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM
 Total_Number_of_Card = 30
@@ -318,9 +318,9 @@ class Advisor:
         if cards_received == 3:
             otherAgent_turnUpdate_3cardsCase(player_makeQuery, claim_suspect, claim_weapon, claim_room, card_givers, self.players)
         elif cards_received == 2:
-            pass
+            otherAgent_turnUpdate_OneTwo_cardsCase(player_makeQuery, claim_suspect, claim_weapon, claim_room, card_givers, self.players, "two")
         elif cards_received == 1:
-            otherAgent_turnUpdate_1cardsCase(player_makeQuery, claim_suspect, claim_weapon, claim_room, card_givers, self.players)
+            otherAgent_turnUpdate_OneTwo_cardsCase(player_makeQuery, claim_suspect, claim_weapon, claim_room, card_givers, self.players, "one")
         elif cards_received == 0:
             otherAgent_turnUpdate_0cardsCase(player_makeQuery, claim_suspect, claim_weapon, claim_room, self.players)
 

--- a/src/main/Advisor.py
+++ b/src/main/Advisor.py
@@ -56,7 +56,8 @@ class Advisor:
                     ## reblance some weight here
                     self.secret_Infer_Rebalance()
                     self.otherAgent_Rebalance()
-                    
+                ## Alert feature, when secret is fully hacked, send notifications.
+                self.alertWin()
             elif action == "Query":
                 what_query = input("Player_Summary / Log / Probability_Table:  ")
                 if what_query == "Log":
@@ -77,6 +78,14 @@ class Advisor:
                 print("Invalid input, enter again")
             print("\n")
     
+    def alertWin(self):
+        if len(self.players["secret"].suspect_must_have) and len(self.players["secret"].weapon_must_have) and len(self.players["secret"].room_must_have):
+            print("Secret Hacked, Make Accusation Now:\n")
+            self.players["secret"].display_suspect_must_have()
+            self.players["secret"].display_weapon_must_have()
+            self.players["secret"].display_room_must_have()
+
+
     def update_myturn(self):
         myQuery = input("My Claim:  ")
         myQuery_suspect, myQuery_weapon, myQuery_room = myQuery.split(",")[0].strip(), myQuery.split(",")[1].strip(), myQuery.split(",")[2].strip()

--- a/src/main/Advisor.py
+++ b/src/main/Advisor.py
@@ -43,6 +43,7 @@ class Advisor:
             if action == "Next turn":
                 whose_turn = input("Whose turn is this: ")
                 if whose_turn == "myself":
+                    self.recommendation()
                     self.update_myturn()
                     self.AI_unit_myselfTurn_update()
                     #break
@@ -85,6 +86,8 @@ class Advisor:
             self.players["secret"].display_weapon_must_have()
             self.players["secret"].display_room_must_have()
 
+    def recommendation(self):
+        pass
 
     def update_myturn(self):
         myQuery = input("My Claim:  ")

--- a/src/main/Advisor.py
+++ b/src/main/Advisor.py
@@ -13,15 +13,15 @@ from agentAIUtils import otherAgent_infer_helper
 from agentAIUtils import otherAgent_turnUpdate_3cardsCase
 from agentAIUtils import otherAgent_turnUpdate_0cardsCase
 
-
+# CONSTANTS in Advisor class, _config
+global Total_Number_of_Card, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM
+Total_Number_of_Card = 30
+LIST_SUSPECT = ["Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Colonel Mustard", "Professor Plum", "Miss Peach", "Sgt. Gray", "Monsieur Brunette", "Mme. Rose"]
+LIST_WEAPON = ["Candlestick", "Knife", "Lead Pipe", "Revolver", "Rope", "Wrench", "Horseshoe", "Poison"]
+LIST_ROOM = ["Carriage House", "Conservatory", "Kitchen", "Trophy Room", "Dining Room", "Drawing Room", "Gazebo", "Courtyard", "Fountain", "Library", "Billiard Room", "Studio"]
 
 class Advisor:
-    # CONSTANTS in Advisor class, _config
-    global Total_Number_of_Card, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM
-    Total_Number_of_Card = 30
-    LIST_SUSPECT = ["Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Colonel Mustard", "Professor Plum", "Miss Peach", "Sgt. Gray", "Monsieur Brunette", "Mme. Rose"]
-    LIST_WEAPON = ["Candlestick", "Knife", "Lead Pipe", "Revolver", "Rope", "Wrench", "Horseshoe", "Poison"]
-    LIST_ROOM = ["Carriage House", "Conservatory", "Kitchen", "Trophy Room", "Dining Room", "Drawing Room", "Gazebo", "Courtyard", "Fountain", "Library", "Billiard Room", "Studio"]
+    
     
     def __init__(self, numberOfPlayers):
         """

--- a/src/main/Advisor.py
+++ b/src/main/Advisor.py
@@ -330,9 +330,9 @@ class Advisor:
         """
         This method make straight forward inferences after each round and rebalance the score of secret agent after each round.
         """
-        secret_infer_helper("suspect", LIST_SUSPECT, self.players)
-        secret_infer_helper("weapon", LIST_WEAPON, self.players)
-        secret_infer_helper("room", LIST_ROOM, self.players)
+        secret_infer_helper("suspect", LIST_SUSPECT, self.players, self.numberOfPlayers)
+        secret_infer_helper("weapon", LIST_WEAPON, self.players, self.numberOfPlayers)
+        secret_infer_helper("room", LIST_ROOM, self.players, self.numberOfPlayers)
 
         ## Rebalance here
         base_value_suspect_secret = self.players["secret"].getSecretBaseValue_suspect()

--- a/src/main/Player.py
+++ b/src/main/Player.py
@@ -172,3 +172,12 @@ class Player:
             return checkItem in self.weapon_must_not_have
         elif checkItem in LIST_ROOM:
             return checkItem in self.room_must_not_have
+
+    ## check if in must_have
+    def check_in_must_have(self, checkItem):
+        if checkItem in LIST_SUSPECT:
+            return checkItem in self.suspect_must_have
+        elif checkItem in LIST_WEAPON:
+            return checkItem in self.weapon_must_have
+        elif checkItem in LIST_ROOM:
+            return checkItem in self.room_must_have

--- a/src/main/Player.py
+++ b/src/main/Player.py
@@ -182,7 +182,7 @@ class Player:
         elif checkItem in LIST_ROOM:
             return checkItem in self.room_must_have
 
-
+    ## check if the ele in possibly set, if so, move to must_have
     def move_ele_possibly_to_must_have(self, ele):
         """
         move an ele from possibly-have set to must-have set
@@ -200,7 +200,7 @@ class Player:
                 del self.room_possibly_have[ele]
             self.update_room_must_have(ele)
 
-
+    ## check if the ele in possibly set, if so, move to must_not_have
     def move_ele_possibly_to_must_not_have(self, ele):
         """
         move an ele from possibly-have set to must-not-have set

--- a/src/main/Player.py
+++ b/src/main/Player.py
@@ -181,3 +181,39 @@ class Player:
             return checkItem in self.weapon_must_have
         elif checkItem in LIST_ROOM:
             return checkItem in self.room_must_have
+
+
+    def move_ele_possibly_to_must_have(self, ele):
+        """
+        move an ele from possibly-have set to must-have set
+        """
+        if ele in LIST_SUSPECT:
+            if ele in self.suspect_possibly_have.keys():
+                del self.suspect_possibly_have[ele]
+            self.update_suspect_must_have(ele)
+        elif ele in LIST_WEAPON:
+            if ele in self.weapon_possibly_have.keys():
+                del self.weapon_possibly_have[ele]
+            self.update_weapon_must_have(ele)
+        else:  ## objectDealing == "room"
+            if ele in self.room_possibly_have.keys():
+                del self.room_possibly_have[ele]
+            self.update_room_must_have(ele)
+
+
+    def move_ele_possibly_to_must_not_have(self, ele):
+        """
+        move an ele from possibly-have set to must-not-have set
+        """
+        if ele in LIST_SUSPECT:
+            if ele in self.suspect_possibly_have.keys():
+                del self.suspect_possibly_have[ele]
+            self.update_suspect_must_not_have(ele)
+        elif ele in LIST_WEAPON:
+            if ele in self.weapon_possibly_have.keys():
+                del self.weapon_possibly_have[ele]
+            self.update_weapon_must_not_have(ele)
+        else:  ## objectDealing == "room"
+            if ele in self.room_possibly_have.keys():
+                del self.room_possibly_have[ele]
+            self.update_room_must_not_have(ele)

--- a/src/test/test_advisor.py
+++ b/src/test/test_advisor.py
@@ -657,5 +657,71 @@ class TestAdvisor(unittest.TestCase):
         self.assertEqual(Advisor11.players["secret"].room_possibly_have,{"Trophy Room": 1/2, "Dining Room": 1/7, "Drawing Room": 1/7, 
         "Courtyard": 1/7, "Fountain": 1/7, "Billiard Room": 1/7, "Studio": 1/7})
 
+
+
+    # Advisor 12
+    # Inherting Advisor 11, validate the 1 cardgivers otherAgent claim turn under 0 or 3 in must-have case, not-include make direct inference
+    @patch("builtins.input", side_effect = ["7", "Miss Scarlet, Mr. Green, Mrs White", "Candlestick, Knife", "Carriage House, Conservatory","Mia, 7", "Michael, 6","Jane,7",
+    "Next turn", "myself", "Mrs Peacock, Rope, Library", "Mia, Michael, Jane",
+    "Next turn", "myself", "Miss Peach, Horseshoe ,Gazebo", "Michael, Jane, None",
+    "Next turn", "myself", "Mme. Rose, Poison, Gazebo", "None, None, Michael", 
+    "Next turn", "myself", "Mme. Rose, Poison, Kitchen", "None, None, Mia",
+    "Next turn", "Michael", "Mme. Rose, Wrench, Gazebo", "None",
+    "Next turn", "Mia", "Colonel Mustard, Revolver, Trophy Room", "None",
+    "Next turn", "Jane", "Sgt. Gray, Lead Pipe, Studio", "Mia",
+    "Next turn", "Jane", "Mme. Rose, Wrench, Library", "Michael",
+    "Query", "Log", "Exit"])
+    def test_Game_12(self, mock_inputs):
+        Advisor12 = Advisor(4)
+        
+        self.assertEqual(Advisor12.players["Michael"].suspect_must_have, {"Miss Peach"})
+        self.assertEqual(Advisor12.players["Michael"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock","Mme. Rose", 
+        "Colonel Mustard", "Sgt. Gray"})
+        self.assertEqual(Advisor12.players["Michael"].suspect_possibly_have, {"Professor Plum": 2/7, "Monsieur Brunette": 2/7})
+        self.assertEqual(Advisor12.players["Michael"].weapon_must_have, {"Rope", "Wrench"})
+        self.assertEqual(Advisor12.players["Michael"].weapon_must_not_have, {"Candlestick", "Knife", "Horseshoe", "Poison", "Revolver","Lead Pipe"})
+        self.assertEqual(Advisor12.players["Michael"].weapon_possibly_have, {})
+        self.assertEqual(Advisor12.players["Michael"].room_must_have, {"Gazebo"})
+        self.assertEqual(Advisor12.players["Michael"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Kitchen","Trophy Room","Studio"})
+        self.assertEqual(Advisor12.players["Michael"].room_possibly_have, {"Dining Room": 2/7, "Drawing Room": 2/7, "Courtyard": 2/7, 
+        "Fountain": 2/7, "Billiard Room": 2/7})
+
+        self.assertEqual(Advisor12.players["Jane"].suspect_must_have,set())
+        self.assertEqual(Advisor12.players["Jane"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Miss Peach", 
+        "Mme. Rose", "Colonel Mustard"})
+        self.assertEqual(Advisor12.players["Jane"].suspect_possibly_have, {"Professor Plum":5/10, "Sgt. Gray": 5/10 + math.log(3/2, 5), 
+        "Monsieur Brunette": 5/10})
+        self.assertEqual(Advisor12.players["Jane"].weapon_must_have, {"Horseshoe"})
+        self.assertEqual(Advisor12.players["Jane"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Poison", "Wrench", "Revolver"})
+        self.assertEqual(Advisor12.players["Jane"].weapon_possibly_have, {"Lead Pipe": 5/10 + math.log(3/2, 5)})
+        self.assertEqual(Advisor12.players["Jane"].room_must_have, {"Library"})
+        self.assertEqual(Advisor12.players["Jane"].room_must_not_have, {"Carriage House", "Conservatory", "Gazebo", "Kitchen","Trophy Room"})
+        self.assertEqual(Advisor12.players["Jane"].room_possibly_have, {"Dining Room":5/10, "Drawing Room":5/10, "Courtyard":5/10, 
+        "Fountain":5/10, "Billiard Room":5/10, "Studio":5/10 + math.log(4/3, 5)})
+                                                                        
+        self.assertEqual(Advisor12.players["Mia"].suspect_must_have,{"Mrs Peacock","Colonel Mustard"})
+        self.assertEqual(Advisor12.players["Mia"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Miss Peach", "Mme. Rose"})
+        self.assertEqual(Advisor12.players["Mia"].suspect_possibly_have, {"Professor Plum": 3/11, "Sgt. Gray": 1/2, "Monsieur Brunette": 3/11})
+        self.assertEqual(Advisor12.players["Mia"].weapon_must_have, {"Revolver"})
+        self.assertEqual(Advisor12.players["Mia"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Horseshoe", "Poison", "Wrench"})
+        self.assertEqual(Advisor12.players["Mia"].weapon_possibly_have, {"Lead Pipe": 1/2})
+        self.assertEqual(Advisor12.players["Mia"].room_must_have, {"Kitchen"})
+        self.assertEqual(Advisor12.players["Mia"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Gazebo"})
+        self.assertEqual(Advisor12.players["Mia"].room_possibly_have, {"Trophy Room":1/2, "Dining Room":3/11, 
+        "Drawing Room":3/11, "Courtyard":3/11, "Fountain":3/11, "Billiard Room":3/11, "Studio":1/3})
+
+        self.assertEqual(Advisor12.players["secret"].suspect_must_have,{"Mme. Rose"})
+        self.assertEqual(Advisor12.players["secret"].suspect_must_not_have,{"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", 
+        "Colonel Mustard", "Professor Plum", "Miss Peach", "Sgt. Gray", "Monsieur Brunette"})
+        self.assertEqual(Advisor12.players["secret"].suspect_possibly_have,{})
+        self.assertEqual(Advisor12.players["secret"].weapon_must_have,{"Poison"})
+        self.assertEqual(Advisor12.players["secret"].weapon_must_not_have,{"Candlestick", "Knife", "Lead Pipe", "Revolver", "Rope", 
+        "Wrench", "Horseshoe"})
+        self.assertEqual(Advisor12.players["secret"].weapon_possibly_have,{})
+        self.assertEqual(Advisor12.players["secret"].room_must_have,set())
+        self.assertEqual(Advisor12.players["secret"].room_must_not_have,{'Library', 'Gazebo', 'Conservatory', 'Kitchen', 'Carriage House'})
+        self.assertEqual(Advisor12.players["secret"].room_possibly_have,{"Trophy Room": 1/2, "Dining Room": 1/7, "Drawing Room": 1/7, 
+        "Courtyard": 1/7, "Fountain": 1/7, "Billiard Room": 1/7, "Studio": 1/3})
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/test_advisor.py
+++ b/src/test/test_advisor.py
@@ -597,5 +597,65 @@ class TestAdvisor(unittest.TestCase):
 
 
 
+    # Advisor 11
+    # Inherting Advisor 10, validate the 0 cardgivers otherAgent claim turn score updates 1/2, include make direct influence action
+    @patch("builtins.input", side_effect = ["7", "Miss Scarlet, Mr. Green, Mrs White", "Candlestick, Knife", "Carriage House, Conservatory","Mia, 7", "Michael, 6","Jane,7",
+    "Next turn", "myself", "Mrs Peacock, Rope, Library", "Mia, Michael, Jane",
+    "Next turn", "myself", "Miss Peach, Horseshoe ,Gazebo", "Michael, Jane, None",
+    "Next turn", "myself", "Mme. Rose, Poison, Gazebo", "None, None, Michael", 
+    "Next turn", "myself", "Mme. Rose, Poison, Kitchen", "None, None, Mia",
+    "Next turn", "Michael", "Mme. Rose, Wrench, Gazebo", "None",
+    "Next turn", "Mia", "Colonel Mustard, Revolver, Trophy Room", "None",
+    "Query", "Player_Summary" ,"Mia", "Exit"])
+    def test_Game_11(self, mock_inputs):
+        Advisor11 = Advisor(4)
+        
+        self.assertEqual(Advisor11.players["Michael"].suspect_must_have, {"Miss Peach"})
+        self.assertEqual(Advisor11.players["Michael"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock","Mme. Rose", "Colonel Mustard"})
+        self.assertEqual(Advisor11.players["Michael"].suspect_possibly_have, {"Professor Plum": 2/10, "Sgt. Gray": 2/10, "Monsieur Brunette": 2/10})
+        self.assertEqual(Advisor11.players["Michael"].weapon_must_have, {"Rope", "Wrench"})
+        self.assertEqual(Advisor11.players["Michael"].weapon_must_not_have, {"Candlestick", "Knife", "Horseshoe", "Poison", "Revolver"})
+        self.assertEqual(Advisor11.players["Michael"].weapon_possibly_have, {"Lead Pipe": 2/10})
+        self.assertEqual(Advisor11.players["Michael"].room_must_have, {"Gazebo"})
+        self.assertEqual(Advisor11.players["Michael"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Kitchen","Trophy Room"})
+        self.assertEqual(Advisor11.players["Michael"].room_possibly_have, {"Dining Room": 2/10, 
+        "Drawing Room": 2/10, "Courtyard": 2/10, "Fountain": 2/10, "Billiard Room": 2/10, "Studio": 2/10})
+
+        self.assertEqual(Advisor11.players["Jane"].suspect_must_have,set())
+        self.assertEqual(Advisor11.players["Jane"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Miss Peach", 
+        "Mme. Rose", "Colonel Mustard"})
+        self.assertEqual(Advisor11.players["Jane"].suspect_possibly_have, {"Professor Plum":5/10, "Sgt. Gray": 5/10, "Monsieur Brunette": 5/10})
+        self.assertEqual(Advisor11.players["Jane"].weapon_must_have, {"Horseshoe"})
+        self.assertEqual(Advisor11.players["Jane"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Poison", "Wrench", "Revolver"})
+        self.assertEqual(Advisor11.players["Jane"].weapon_possibly_have, {"Lead Pipe": 5/10})
+        self.assertEqual(Advisor11.players["Jane"].room_must_have, {"Library"})
+        self.assertEqual(Advisor11.players["Jane"].room_must_not_have, {"Carriage House", "Conservatory", "Gazebo", "Kitchen","Trophy Room"})
+        self.assertEqual(Advisor11.players["Jane"].room_possibly_have, {"Dining Room":5/10, 
+        "Drawing Room":5/10, "Courtyard":5/10, "Fountain":5/10, "Billiard Room":5/10, "Studio":5/10})
+                                                                        
+        self.assertEqual(Advisor11.players["Mia"].suspect_must_have,{"Mrs Peacock","Colonel Mustard"})
+        self.assertEqual(Advisor11.players["Mia"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Miss Peach", "Mme. Rose"})
+        self.assertEqual(Advisor11.players["Mia"].suspect_possibly_have, {"Professor Plum": 3/11, "Sgt. Gray": 3/11, "Monsieur Brunette": 3/11})
+        self.assertEqual(Advisor11.players["Mia"].weapon_must_have, {"Revolver"})
+        self.assertEqual(Advisor11.players["Mia"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Horseshoe", "Poison", "Wrench"})
+        self.assertEqual(Advisor11.players["Mia"].weapon_possibly_have, {"Lead Pipe": 3/11})
+        self.assertEqual(Advisor11.players["Mia"].room_must_have, {"Kitchen"})
+        self.assertEqual(Advisor11.players["Mia"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Gazebo"})
+        self.assertEqual(Advisor11.players["Mia"].room_possibly_have, {"Trophy Room":1/2, "Dining Room":3/11, 
+        "Drawing Room":3/11, "Courtyard":3/11, "Fountain":3/11, "Billiard Room":3/11, "Studio":3/11})
+
+        self.assertEqual(Advisor11.players["secret"].suspect_must_have,{"Mme. Rose"})
+        self.assertEqual(Advisor11.players["secret"].suspect_must_not_have,{"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", 
+        "Colonel Mustard", "Professor Plum", "Miss Peach", "Sgt. Gray", "Monsieur Brunette"})
+        self.assertEqual(Advisor11.players["secret"].suspect_possibly_have,{})
+        self.assertEqual(Advisor11.players["secret"].weapon_must_have,{"Poison"})
+        self.assertEqual(Advisor11.players["secret"].weapon_must_not_have,{"Candlestick", "Knife", "Lead Pipe", "Revolver", "Rope", 
+        "Wrench", "Horseshoe"})
+        self.assertEqual(Advisor11.players["secret"].weapon_possibly_have,{})
+        self.assertEqual(Advisor11.players["secret"].room_must_have,set())
+        self.assertEqual(Advisor11.players["secret"].room_must_not_have,{'Library', 'Gazebo', 'Conservatory', 'Kitchen', 'Carriage House'})
+        self.assertEqual(Advisor11.players["secret"].room_possibly_have,{"Trophy Room": 1/2, "Dining Room": 1/7, "Drawing Room": 1/7, 
+        "Courtyard": 1/7, "Fountain": 1/7, "Billiard Room": 1/7, "Studio": 1/7})
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/test_advisor.py
+++ b/src/test/test_advisor.py
@@ -475,7 +475,7 @@ class TestAdvisor(unittest.TestCase):
     "Next turn", "Michael", "Mrs White, Lead Pipe, Fountain", "myself, Mia, Jane",
     "Next turn", "Jane", "Mrs Peacock, Rope, Conservatory", "Mia, Michael, myself",
     "Next turn", "Mia", "Miss Scarlet, Horseshoe, Drawing Room", "myself, Jane, Michael",
-    "Exit"])
+    "Query", "Player_Summary", "Michael","Exit"])
     def test_Game9(self, mock_inputs):
         Advisor9 = Advisor(4)
 
@@ -534,18 +534,66 @@ class TestAdvisor(unittest.TestCase):
 
     
     # Advisor 10
-    # 
+    # Inherting Advisor 5, validate the 0 cardgivers otherAgent claim turn, include make direct influence action
     @patch("builtins.input", side_effect = ["7", "Miss Scarlet, Mr. Green, Mrs White", "Candlestick, Knife", "Carriage House, Conservatory","Mia, 7", "Michael, 6","Jane,7",
     "Next turn", "myself", "Mrs Peacock, Rope, Library", "Mia, Michael, Jane",
     "Next turn", "myself", "Miss Peach, Horseshoe ,Gazebo", "Michael, Jane, None",
     "Next turn", "myself", "Mme. Rose, Poison, Gazebo", "None, None, Michael", 
-    "Query", "Player_Summary", "Michael", "Exit"])
-    def test_Game10(self, mock_inputs):
+    "Next turn", "myself", "Mme. Rose, Poison, Kitchen", "None, None, Mia",
+    "Next turn", "Michael", "Mme. Rose, Wrench, Gazebo", "None",
+    "Query", "Log", "Exit"])
+    def test_Game_10(self, mock_inputs):
         Advisor10 = Advisor(4)
-
+        
         self.assertEqual(Advisor10.players["Michael"].suspect_must_have, {"Miss Peach"})
-        self.assertEqual(Advisor10.players["Michael"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock"})
+        self.assertEqual(Advisor10.players["Michael"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock","Mme. Rose"})
+        self.assertEqual(Advisor10.players["Michael"].suspect_possibly_have, {"Colonel Mustard": 2/13, "Professor Plum": 2/13, 
+        "Sgt. Gray": 2/13, "Monsieur Brunette": 2/13})
+        self.assertEqual(Advisor10.players["Michael"].weapon_must_have, {"Rope", "Wrench"})
+        self.assertEqual(Advisor10.players["Michael"].weapon_must_not_have, {"Candlestick", "Knife", "Horseshoe", "Poison"})
+        self.assertEqual(Advisor10.players["Michael"].weapon_possibly_have, {"Lead Pipe": 2/13, "Revolver": 2/13})
+        self.assertEqual(Advisor10.players["Michael"].room_must_have, {"Gazebo"})
+        self.assertEqual(Advisor10.players["Michael"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Kitchen"})
+        self.assertEqual(Advisor10.players["Michael"].room_possibly_have, {"Trophy Room": 2/13, "Dining Room": 2/13, 
+        "Drawing Room": 2/13, "Courtyard": 2/13, "Fountain": 2/13, "Billiard Room": 2/13, "Studio": 2/13})
 
+        self.assertEqual(Advisor10.players["Jane"].suspect_must_have,set())
+        self.assertEqual(Advisor10.players["Jane"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Miss Peach", 
+        "Mme. Rose"})
+        self.assertEqual(Advisor10.players["Jane"].suspect_possibly_have, {"Colonel Mustard":5/13, "Professor Plum":5/13, 
+        "Sgt. Gray": 5/13, "Monsieur Brunette": 5/13})
+        self.assertEqual(Advisor10.players["Jane"].weapon_must_have, {"Horseshoe"})
+        self.assertEqual(Advisor10.players["Jane"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Poison", "Wrench"})
+        self.assertEqual(Advisor10.players["Jane"].weapon_possibly_have, {"Lead Pipe": 5/13, "Revolver": 5/13})
+        self.assertEqual(Advisor10.players["Jane"].room_must_have, {"Library"})
+        self.assertEqual(Advisor10.players["Jane"].room_must_not_have, {"Carriage House", "Conservatory", "Gazebo", "Kitchen"})
+        self.assertEqual(Advisor10.players["Jane"].room_possibly_have, {"Trophy Room":5/13, "Dining Room":5/13, 
+        "Drawing Room":5/13, "Courtyard":5/13, "Fountain":5/13, "Billiard Room":5/13, "Studio":5/13})
+                                                                        
+        self.assertEqual(Advisor10.players["Mia"].suspect_must_have,{"Mrs Peacock"})
+        self.assertEqual(Advisor10.players["Mia"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Miss Peach", "Mme. Rose"})
+        self.assertEqual(Advisor10.players["Mia"].suspect_possibly_have, {"Colonel Mustard": 5/13, "Professor Plum": 5/13, 
+        "Sgt. Gray": 5/13, "Monsieur Brunette": 5/13})
+        self.assertEqual(Advisor10.players["Mia"].weapon_must_have, set())
+        self.assertEqual(Advisor10.players["Mia"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Horseshoe", "Poison", "Wrench"})
+        self.assertEqual(Advisor10.players["Mia"].weapon_possibly_have, {"Lead Pipe": 5/13, "Revolver":5/13})
+        self.assertEqual(Advisor10.players["Mia"].room_must_have, {"Kitchen"})
+        self.assertEqual(Advisor10.players["Mia"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Gazebo"})
+        self.assertEqual(Advisor10.players["Mia"].room_possibly_have, {"Trophy Room":5/13, "Dining Room":5/13, 
+        "Drawing Room":5/13, "Courtyard":5/13, "Fountain":5/13, "Billiard Room":5/13, "Studio":5/13})
+
+        self.assertEqual(Advisor10.players["secret"].suspect_must_have,{"Mme. Rose"})
+        self.assertEqual(Advisor10.players["secret"].suspect_must_not_have,{"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", 
+        "Colonel Mustard", "Professor Plum", "Miss Peach", "Sgt. Gray", "Monsieur Brunette"})
+        self.assertEqual(Advisor10.players["secret"].suspect_possibly_have,{})
+        self.assertEqual(Advisor10.players["secret"].weapon_must_have,{"Poison"})
+        self.assertEqual(Advisor10.players["secret"].weapon_must_not_have,{"Candlestick", "Knife", "Lead Pipe", "Revolver", "Rope", 
+        "Wrench", "Horseshoe"})
+        self.assertEqual(Advisor10.players["secret"].weapon_possibly_have,{})
+        self.assertEqual(Advisor10.players["secret"].room_must_have,set())
+        self.assertEqual(Advisor10.players["secret"].room_must_not_have,{'Library', 'Gazebo', 'Conservatory', 'Kitchen', 'Carriage House'})
+        self.assertEqual(Advisor10.players["secret"].room_possibly_have,{"Trophy Room": 1/7, "Dining Room": 1/7, "Drawing Room": 1/7, 
+        "Courtyard": 1/7, "Fountain": 1/7, "Billiard Room": 1/7, "Studio": 1/7})
 
 
 

--- a/src/test/test_advisor.py
+++ b/src/test/test_advisor.py
@@ -475,7 +475,7 @@ class TestAdvisor(unittest.TestCase):
     "Next turn", "Michael", "Mrs White, Lead Pipe, Fountain", "myself, Mia, Jane",
     "Next turn", "Jane", "Mrs Peacock, Rope, Conservatory", "Mia, Michael, myself",
     "Next turn", "Mia", "Miss Scarlet, Horseshoe, Drawing Room", "myself, Jane, Michael",
-    "Query","Player_Summary","Mia","Exit"])
+    "Query","Log","Exit"])
     def test_Game9(self, mock_inputs):
         Advisor9 = Advisor(4)
 

--- a/src/test/test_advisor.py
+++ b/src/test/test_advisor.py
@@ -793,7 +793,7 @@ class TestAdvisor(unittest.TestCase):
     
 
     # Adivisor 14
-    # Inherit Advisor9, to validate the otherAgent turn 2 cardgivers cases, randomly test it with score udpates, and direct inferences
+    # Inherit Advisor9, to validate the otherAgent turn 2 cardgivers cases, randomly test it with score udpates, and without direct inferences
     @patch("builtins.input", side_effect = ["7", "Miss Scarlet, Mr. Green, Mrs White", "Candlestick, Knife", "Carriage House, Conservatory","Mia, 7", "Michael, 6","Jane,7",
     "Next turn", "myself", "Mrs Peacock, Rope, Library", "Mia, Michael, Jane",
     "Next turn", "myself", "Miss Peach, Horseshoe ,Gazebo", "Michael, Jane, None",
@@ -802,7 +802,7 @@ class TestAdvisor(unittest.TestCase):
     "Next turn", "Jane", "Mrs Peacock, Rope, Conservatory", "Mia, Michael, myself",
     "Next turn", "Mia", "Miss Scarlet, Horseshoe, Drawing Room", "myself, Jane, Michael",
     "Next turn", "Michael", "Mme. Rose, Revolver ,Courtyard", "Mia, Jane",
-    "Query", "Player_Summary", "Michael","Exit"])
+    "Query", "Log","Exit"])
     def test_Game_14(self, mock_inpupts):
         Advisor14 = Advisor(4)
 
@@ -858,6 +858,72 @@ class TestAdvisor(unittest.TestCase):
         self.assertEqual(Advisor14.players["secret"].room_possibly_have, {"Kitchen": 1/6, "Trophy Room": 1/6, "Dining Room": 1/6, 
         "Courtyard": 1/4, "Billiard Room": 1/6, "Studio": 1/6})
     
+
+    # Adivisor 15
+    # Inherit Advisor14, to validate the otherAgent turn 2 cardgivers cases, randomly test it with score udpates, and with direct inferences
+    @patch("builtins.input", side_effect = ["7", "Miss Scarlet, Mr. Green, Mrs White", "Candlestick, Knife", "Carriage House, Conservatory","Mia, 7", "Michael, 6","Jane,7",
+    "Next turn", "myself", "Mrs Peacock, Rope, Library", "Mia, Michael, Jane",
+    "Next turn", "myself", "Miss Peach, Horseshoe ,Gazebo", "Michael, Jane, None",
+    "Next turn", "myself", "Mme. Rose, Poison, Gazebo", "None, None, Michael", 
+    "Next turn", "Michael", "Mrs White, Lead Pipe, Fountain", "myself, Mia, Jane",
+    "Next turn", "Jane", "Mrs Peacock, Rope, Conservatory", "Mia, Michael, myself",
+    "Next turn", "Mia", "Miss Scarlet, Horseshoe, Drawing Room", "myself, Jane, Michael",
+    "Next turn", "Michael", "Mme. Rose, Revolver ,Courtyard", "Mia, Jane",
+    "Next turn", "Jane", "Mme. Rose, Lead Pipe, Carriage House", "Mia, myself",
+    "Query", "Player_Summary","secret","Exit"])
+    def test_Game_15(self, mock_inputs):
+        Advisor15 = Advisor(4)
+
+        self.assertEqual(Advisor15.players["Michael"].suspect_must_have, {"Miss Peach"})
+        self.assertEqual(Advisor15.players["Michael"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Mme. Rose"})
+        self.assertEqual(Advisor15.players["Michael"].suspect_possibly_have, {"Colonel Mustard": 2/13, "Professor Plum": 2/13, 
+        "Sgt. Gray": 2/13, "Monsieur Brunette": 2/13})
+        self.assertEqual(Advisor15.players["Michael"].weapon_must_have, {"Rope"})
+        self.assertEqual(Advisor15.players["Michael"].weapon_must_not_have, {"Candlestick", "Knife", "Horseshoe", "Lead Pipe"})
+        self.assertEqual(Advisor15.players["Michael"].weapon_possibly_have, {"Revolver": 1/4, "Wrench": 2/13, "Poison": 1/2})
+        self.assertEqual(Advisor15.players["Michael"].room_must_have, {"Gazebo","Drawing Room"})
+        self.assertEqual(Advisor15.players["Michael"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Fountain"})
+        self.assertEqual(Advisor15.players["Michael"].room_possibly_have, {"Kitchen": 2/13, "Trophy Room": 2/13, "Dining Room": 2/13, 
+        "Courtyard": 1/4, "Billiard Room": 2/13, "Studio": 2/13})
+
+        self.assertEqual(Advisor15.players["Jane"].suspect_must_have,set())
+        self.assertEqual(Advisor15.players["Jane"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Miss Peach", 
+        "Mme. Rose"})
+        self.assertEqual(Advisor15.players["Jane"].suspect_possibly_have, {"Colonel Mustard":5/14, "Professor Plum": 5/14, 
+        "Sgt. Gray": 5/14, "Monsieur Brunette": 5/14})
+        self.assertEqual(Advisor15.players["Jane"].weapon_must_have, {"Horseshoe"})
+        self.assertEqual(Advisor15.players["Jane"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Poison"})
+        self.assertEqual(Advisor15.players["Jane"].weapon_possibly_have, {"Lead Pipe": 1/2 + math.log(0.5 + 1/2 + 1/2, 5), "Revolver": 5/14, "Wrench": 5/14 })
+        self.assertEqual(Advisor15.players["Jane"].room_must_have, {"Library"})
+        self.assertEqual(Advisor15.players["Jane"].room_must_not_have, {"Carriage House", "Conservatory", "Gazebo","Drawing Room"})
+        self.assertEqual(Advisor15.players["Jane"].room_possibly_have, {"Kitchen": 5/14, "Trophy Room":5/14, "Dining Room":5/14, 
+        "Courtyard":5/14, "Fountain":1/2, "Billiard Room":5/14, "Studio":5/14})
+                                                                        
+        self.assertEqual(Advisor15.players["Mia"].suspect_must_have,{"Mrs Peacock"})
+        self.assertEqual(Advisor15.players["Mia"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Miss Peach", "Mme. Rose"})
+        self.assertEqual(Advisor15.players["Mia"].suspect_possibly_have, {"Colonel Mustard": 6/14, "Professor Plum": 6/14, 
+        "Sgt. Gray": 6/14, "Monsieur Brunette": 6/14})
+        self.assertEqual(Advisor15.players["Mia"].weapon_must_have, set())
+        self.assertEqual(Advisor15.players["Mia"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Horseshoe", "Poison"})
+        self.assertEqual(Advisor15.players["Mia"].weapon_possibly_have, {"Lead Pipe": 1/2 + math.log(0.5 + 1/2 + 1/2, 5), "Revolver":6/14, "Wrench":6/14})
+        self.assertEqual(Advisor15.players["Mia"].room_must_have, set())
+        self.assertEqual(Advisor15.players["Mia"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Gazebo", "Drawing Room"})
+        self.assertEqual(Advisor15.players["Mia"].room_possibly_have, {"Kitchen": 6/14, "Trophy Room":6/14, "Dining Room":6/14, 
+        "Courtyard":6/14, "Fountain":1/2, "Billiard Room":6/14, "Studio":6/14})
+
+        self.assertEqual(Advisor15.players["secret"].suspect_must_have,{"Mme. Rose"})
+        self.assertEqual(Advisor15.players["secret"].suspect_must_not_have,{"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Miss Peach",
+        "Colonel Mustard", "Professor Plum", "Sgt. Gray", "Monsieur Brunette"})
+        self.assertEqual(Advisor15.players["secret"].suspect_possibly_have, {})
+
+        self.assertEqual(Advisor15.players["secret"].weapon_must_have,set())
+        self.assertEqual(Advisor15.players["secret"].weapon_must_not_have,{"Candlestick", "Knife", "Rope", "Horseshoe","Lead Pipe"})
+        self.assertEqual(Advisor15.players["secret"].weapon_possibly_have, {"Revolver": 1/3, "Wrench": 1/3, "Poison": 1/2})
+
+        self.assertEqual(Advisor15.players["secret"].room_must_have,set())
+        self.assertEqual(Advisor15.players["secret"].room_must_not_have,{"Carriage House", "Conservatory", "Library", "Gazebo","Fountain", "Drawing Room"})
+        self.assertEqual(Advisor15.players["secret"].room_possibly_have, {"Kitchen": 1/6, "Trophy Room": 1/6, "Dining Room": 1/6, 
+        "Courtyard": 1/4, "Billiard Room": 1/6, "Studio": 1/6})
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/test_advisor.py
+++ b/src/test/test_advisor.py
@@ -789,5 +789,75 @@ class TestAdvisor(unittest.TestCase):
         self.assertEqual(Advisor13.players["secret"].room_possibly_have,{"Trophy Room": 1/2, "Dining Room": 1/7, "Drawing Room": 1/7, 
         "Courtyard": 1/7, "Fountain": 1/7, "Billiard Room": 1/7, "Studio": 1/2})
 
+
+    
+
+    # Adivisor 14
+    # Inherit Advisor9, to validate the otherAgent turn 2 cardgivers cases, randomly test it with score udpates, and direct inferences
+    @patch("builtins.input", side_effect = ["7", "Miss Scarlet, Mr. Green, Mrs White", "Candlestick, Knife", "Carriage House, Conservatory","Mia, 7", "Michael, 6","Jane,7",
+    "Next turn", "myself", "Mrs Peacock, Rope, Library", "Mia, Michael, Jane",
+    "Next turn", "myself", "Miss Peach, Horseshoe ,Gazebo", "Michael, Jane, None",
+    "Next turn", "myself", "Mme. Rose, Poison, Gazebo", "None, None, Michael", 
+    "Next turn", "Michael", "Mrs White, Lead Pipe, Fountain", "myself, Mia, Jane",
+    "Next turn", "Jane", "Mrs Peacock, Rope, Conservatory", "Mia, Michael, myself",
+    "Next turn", "Mia", "Miss Scarlet, Horseshoe, Drawing Room", "myself, Jane, Michael",
+    "Next turn", "Michael", "Mme. Rose, Revolver ,Courtyard", "Mia, Jane",
+    "Query", "Player_Summary", "Michael","Exit"])
+    def test_Game_14(self, mock_inpupts):
+        Advisor14 = Advisor(4)
+
+        self.assertEqual(Advisor14.players["Michael"].suspect_must_have, {"Miss Peach"})
+        self.assertEqual(Advisor14.players["Michael"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock"})
+        self.assertEqual(Advisor14.players["Michael"].suspect_possibly_have, {"Colonel Mustard": 2/14, "Professor Plum": 2/14, 
+        "Sgt. Gray": 2/14, "Monsieur Brunette": 2/14, "Mme. Rose": 1/2 + math.log(3/2, 5) })
+        self.assertEqual(Advisor14.players["Michael"].weapon_must_have, {"Rope"})
+        self.assertEqual(Advisor14.players["Michael"].weapon_must_not_have, {"Candlestick", "Knife", "Horseshoe", "Lead Pipe"})
+        self.assertEqual(Advisor14.players["Michael"].weapon_possibly_have, {"Revolver": 1/4, "Wrench": 2/14, "Poison": 1/2})
+        self.assertEqual(Advisor14.players["Michael"].room_must_have, {"Gazebo","Drawing Room"})
+        self.assertEqual(Advisor14.players["Michael"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Fountain"})
+        self.assertEqual(Advisor14.players["Michael"].room_possibly_have, {"Kitchen": 2/14, "Trophy Room": 2/14, "Dining Room": 2/14, 
+        "Courtyard": 1/4, "Billiard Room": 2/14, "Studio": 2/14})
+
+        self.assertEqual(Advisor14.players["Jane"].suspect_must_have,set())
+        self.assertEqual(Advisor14.players["Jane"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Miss Peach", 
+        "Mme. Rose"})
+        self.assertEqual(Advisor14.players["Jane"].suspect_possibly_have, {"Colonel Mustard":5/14, "Professor Plum": 5/14, 
+        "Sgt. Gray": 5/14, "Monsieur Brunette": 5/14})
+        self.assertEqual(Advisor14.players["Jane"].weapon_must_have, {"Horseshoe"})
+        self.assertEqual(Advisor14.players["Jane"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Poison"})
+        self.assertEqual(Advisor14.players["Jane"].weapon_possibly_have, {"Lead Pipe": 1/2, "Revolver": 5/14, "Wrench": 5/14 })
+        self.assertEqual(Advisor14.players["Jane"].room_must_have, {"Library"})
+        self.assertEqual(Advisor14.players["Jane"].room_must_not_have, {"Carriage House", "Conservatory", "Gazebo","Drawing Room"})
+        self.assertEqual(Advisor14.players["Jane"].room_possibly_have, {"Kitchen": 5/14, "Trophy Room":5/14, "Dining Room":5/14, 
+        "Courtyard":5/14, "Fountain":1/2, "Billiard Room":5/14, "Studio":5/14})
+                                                                        
+        self.assertEqual(Advisor14.players["Mia"].suspect_must_have,{"Mrs Peacock"})
+        self.assertEqual(Advisor14.players["Mia"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Miss Peach", "Mme. Rose"})
+        self.assertEqual(Advisor14.players["Mia"].suspect_possibly_have, {"Colonel Mustard": 6/14, "Professor Plum": 6/14, 
+        "Sgt. Gray": 6/14, "Monsieur Brunette": 6/14})
+        self.assertEqual(Advisor14.players["Mia"].weapon_must_have, set())
+        self.assertEqual(Advisor14.players["Mia"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Horseshoe", "Poison"})
+        self.assertEqual(Advisor14.players["Mia"].weapon_possibly_have, {"Lead Pipe": 1/2, "Revolver":6/14, "Wrench":6/14})
+        self.assertEqual(Advisor14.players["Mia"].room_must_have, set())
+        self.assertEqual(Advisor14.players["Mia"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Gazebo", "Drawing Room"})
+        self.assertEqual(Advisor14.players["Mia"].room_possibly_have, {"Kitchen": 6/14, "Trophy Room":6/14, "Dining Room":6/14, 
+        "Courtyard":6/14, "Fountain":1/2, "Billiard Room":6/14, "Studio":6/14})
+
+        self.assertEqual(Advisor14.players["secret"].suspect_must_have,set())
+        self.assertEqual(Advisor14.players["secret"].suspect_must_not_have,{"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Miss Peach"})
+        self.assertEqual(Advisor14.players["secret"].suspect_possibly_have, {"Colonel Mustard": 1/5, "Professor Plum": 1/5, 
+        "Sgt. Gray": 1/5, "Monsieur Brunette": 1/5, "Mme. Rose": 1/2 + math.log(0.5 + 1/2 + 1/2, 5)})
+
+        self.assertEqual(Advisor14.players["secret"].weapon_must_have,set())
+        self.assertEqual(Advisor14.players["secret"].weapon_must_not_have,{"Candlestick", "Knife", "Rope", "Horseshoe","Lead Pipe"})
+        self.assertEqual(Advisor14.players["secret"].weapon_possibly_have, {"Revolver": 1/3, "Wrench": 1/3, 
+        "Poison": 1/2})
+
+        self.assertEqual(Advisor14.players["secret"].room_must_have,set())
+        self.assertEqual(Advisor14.players["secret"].room_must_not_have,{"Carriage House", "Conservatory", "Library", "Gazebo","Fountain", "Drawing Room"})
+        self.assertEqual(Advisor14.players["secret"].room_possibly_have, {"Kitchen": 1/6, "Trophy Room": 1/6, "Dining Room": 1/6, 
+        "Courtyard": 1/4, "Billiard Room": 1/6, "Studio": 1/6})
+    
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/test_advisor.py
+++ b/src/test/test_advisor.py
@@ -723,5 +723,71 @@ class TestAdvisor(unittest.TestCase):
         self.assertEqual(Advisor12.players["secret"].room_possibly_have,{"Trophy Room": 1/2, "Dining Room": 1/7, "Drawing Room": 1/7, 
         "Courtyard": 1/7, "Fountain": 1/7, "Billiard Room": 1/7, "Studio": 1/3})
 
+
+    # Advisor 13
+    # Inherting Advisor 12, validate the 1 cardgivers otherAgent claim turn under 1 or 2 in must-have case, include direct inference case
+    @patch("builtins.input", side_effect = ["7", "Miss Scarlet, Mr. Green, Mrs White", "Candlestick, Knife", "Carriage House, Conservatory","Mia, 7", "Michael, 6","Jane,7",
+    "Next turn", "myself", "Mrs Peacock, Rope, Library", "Mia, Michael, Jane",
+    "Next turn", "myself", "Miss Peach, Horseshoe ,Gazebo", "Michael, Jane, None",
+    "Next turn", "myself", "Mme. Rose, Poison, Gazebo", "None, None, Michael", 
+    "Next turn", "myself", "Mme. Rose, Poison, Kitchen", "None, None, Mia",
+    "Next turn", "Michael", "Mme. Rose, Wrench, Gazebo", "None",
+    "Next turn", "Mia", "Colonel Mustard, Revolver, Trophy Room", "None",
+    "Next turn", "Jane", "Sgt. Gray, Lead Pipe, Studio", "Mia",
+    "Next turn", "Jane", "Mme. Rose, Wrench, Library", "Michael",
+    "Next turn", "Michael", "Sgt. Gray, Poison, Studio", "Jane",
+    "Query", "Log", 
+    "Query", "Player_Summary", "Jane", "Exit"])
+    def test_Game_13(self, mock_inputs):
+        Advisor13 = Advisor(4)
+
+        self.assertEqual(Advisor13.players["Michael"].suspect_must_have, {"Miss Peach"})
+        self.assertEqual(Advisor13.players["Michael"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock","Mme. Rose", 
+        "Colonel Mustard", "Sgt. Gray"})
+        self.assertEqual(Advisor13.players["Michael"].suspect_possibly_have, {"Professor Plum": 2/7, "Monsieur Brunette": 2/7})
+        self.assertEqual(Advisor13.players["Michael"].weapon_must_have, {"Rope", "Wrench"})
+        self.assertEqual(Advisor13.players["Michael"].weapon_must_not_have, {"Candlestick", "Knife", "Horseshoe", "Poison", "Revolver","Lead Pipe"})
+        self.assertEqual(Advisor13.players["Michael"].weapon_possibly_have, {})
+        self.assertEqual(Advisor13.players["Michael"].room_must_have, {"Gazebo"})
+        self.assertEqual(Advisor13.players["Michael"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Kitchen","Trophy Room","Studio"})
+        self.assertEqual(Advisor13.players["Michael"].room_possibly_have, {"Dining Room": 2/7, "Drawing Room": 2/7, "Courtyard": 2/7, 
+        "Fountain": 2/7, "Billiard Room": 2/7})
+
+        self.assertEqual(Advisor13.players["Jane"].suspect_must_have, {"Sgt. Gray"})
+        self.assertEqual(Advisor13.players["Jane"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Miss Peach", 
+        "Mme. Rose", "Colonel Mustard"})
+        self.assertEqual(Advisor13.players["Jane"].suspect_possibly_have, {"Professor Plum": 4/9, "Monsieur Brunette": 4/9})
+        self.assertEqual(Advisor13.players["Jane"].weapon_must_have, {"Horseshoe"})
+        self.assertEqual(Advisor13.players["Jane"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Poison", "Wrench", "Revolver"})
+        self.assertEqual(Advisor13.players["Jane"].weapon_possibly_have, {"Lead Pipe": 5/10 + math.log(3/2, 5)})
+        self.assertEqual(Advisor13.players["Jane"].room_must_have, {"Library"})
+        self.assertEqual(Advisor13.players["Jane"].room_must_not_have, {"Carriage House", "Conservatory", "Gazebo", "Kitchen","Trophy Room"})
+        self.assertEqual(Advisor13.players["Jane"].room_possibly_have, {"Dining Room":4/9, "Drawing Room":4/9, "Courtyard": 4/9, 
+        "Fountain":4/9, "Billiard Room":4/9, "Studio":5/10 + math.log(4/3, 5) + math.log(1 + math.log(4/3, 5) + 1/2, 5)})
+                                                                        
+        self.assertEqual(Advisor13.players["Mia"].suspect_must_have,{"Mrs Peacock","Colonel Mustard"})
+        self.assertEqual(Advisor13.players["Mia"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Miss Peach", "Mme. Rose", "Sgt. Gray"})
+        self.assertEqual(Advisor13.players["Mia"].suspect_possibly_have, {"Professor Plum": 3/9, "Monsieur Brunette": 3/9})
+        self.assertEqual(Advisor13.players["Mia"].weapon_must_have, {"Revolver"})
+        self.assertEqual(Advisor13.players["Mia"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Horseshoe", "Poison", "Wrench"})
+        self.assertEqual(Advisor13.players["Mia"].weapon_possibly_have, {"Lead Pipe": 1/2})
+        self.assertEqual(Advisor13.players["Mia"].room_must_have, {"Kitchen"})
+        self.assertEqual(Advisor13.players["Mia"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Gazebo","Studio"})
+        self.assertEqual(Advisor13.players["Mia"].room_possibly_have, {"Trophy Room":1/2, "Dining Room":3/9, 
+        "Drawing Room":3/9, "Courtyard":3/9, "Fountain":3/9, "Billiard Room":3/9})
+
+        self.assertEqual(Advisor13.players["secret"].suspect_must_have,{"Mme. Rose"})
+        self.assertEqual(Advisor13.players["secret"].suspect_must_not_have,{"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", 
+        "Colonel Mustard", "Professor Plum", "Miss Peach", "Sgt. Gray", "Monsieur Brunette"})
+        self.assertEqual(Advisor13.players["secret"].suspect_possibly_have,{})
+        self.assertEqual(Advisor13.players["secret"].weapon_must_have,{"Poison"})
+        self.assertEqual(Advisor13.players["secret"].weapon_must_not_have,{"Candlestick", "Knife", "Lead Pipe", "Revolver", "Rope", 
+        "Wrench", "Horseshoe"})
+        self.assertEqual(Advisor13.players["secret"].weapon_possibly_have,{})
+        self.assertEqual(Advisor13.players["secret"].room_must_have,set())
+        self.assertEqual(Advisor13.players["secret"].room_must_not_have,{'Library', 'Gazebo', 'Conservatory', 'Kitchen', 'Carriage House'})
+        self.assertEqual(Advisor13.players["secret"].room_possibly_have,{"Trophy Room": 1/2, "Dining Room": 1/7, "Drawing Room": 1/7, 
+        "Courtyard": 1/7, "Fountain": 1/7, "Billiard Room": 1/7, "Studio": 1/2})
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/test_advisor.py
+++ b/src/test/test_advisor.py
@@ -340,8 +340,8 @@ class TestAdvisor(unittest.TestCase):
     "Next turn", "myself", "Mme. Rose, Poison, Gazebo", "None, None, Michael", 
     "Next turn", "myself", "Mme. Rose, Poison, Drawing Room", "None, None, Michael",
     "Magnifier", "Mia, Kitchen",
-    "Magnifier", "Jane, Horseshoe",
-    "Query","Log","Exit"])
+    "Magnifier", "Jane, Horseshoe", "Exit"])
+    #"Query","Log","Exit"])
     def test_Game7(self, mock_inputs):
         Advisor7 = Advisor(4)
 
@@ -408,8 +408,8 @@ class TestAdvisor(unittest.TestCase):
     "Next turn", "myself", "Miss Peach, Horseshoe ,Gazebo", "Michael, Jane, None",
     "Next turn", "myself", "Mme. Rose, Poison, Gazebo", "None, None, Michael", 
     "Next turn", "Michael", "Mrs White, Lead Pipe, Fountain", "myself, Mia, Jane",
-    "Next turn", "Jane", "Mrs Peacock, Rope, Conservatory", "Mia, Michael, myself",
-    "Query","Player_Summary","Michael","Exit"])
+    "Next turn", "Jane", "Mrs Peacock, Rope, Conservatory", "Mia, Michael, myself", "Exit"])
+    #"Query","Player_Summary","Michael","Exit"])
     def test_Game8(self, mock_inputs):
         Advisor8 = Advisor(4)
 
@@ -475,7 +475,7 @@ class TestAdvisor(unittest.TestCase):
     "Next turn", "Michael", "Mrs White, Lead Pipe, Fountain", "myself, Mia, Jane",
     "Next turn", "Jane", "Mrs Peacock, Rope, Conservatory", "Mia, Michael, myself",
     "Next turn", "Mia", "Miss Scarlet, Horseshoe, Drawing Room", "myself, Jane, Michael",
-    "Query","Log","Exit"])
+    "Exit"])
     def test_Game9(self, mock_inputs):
         Advisor9 = Advisor(4)
 
@@ -530,6 +530,23 @@ class TestAdvisor(unittest.TestCase):
         self.assertEqual(Advisor9.players["secret"].room_must_not_have,{"Carriage House", "Conservatory", "Library", "Gazebo","Fountain", "Drawing Room"})
         self.assertEqual(Advisor9.players["secret"].room_possibly_have, {"Kitchen": 1/6, "Trophy Room": 1/6, "Dining Room": 1/6, 
         "Courtyard": 1/6, "Billiard Room": 1/6, "Studio": 1/6})
+
+
+    
+    # Advisor 10
+    # 
+    @patch("builtins.input", side_effect = ["7", "Miss Scarlet, Mr. Green, Mrs White", "Candlestick, Knife", "Carriage House, Conservatory","Mia, 7", "Michael, 6","Jane,7",
+    "Next turn", "myself", "Mrs Peacock, Rope, Library", "Mia, Michael, Jane",
+    "Next turn", "myself", "Miss Peach, Horseshoe ,Gazebo", "Michael, Jane, None",
+    "Next turn", "myself", "Mme. Rose, Poison, Gazebo", "None, None, Michael", 
+    "Query", "Player_Summary", "Michael", "Exit"])
+    def test_Game10(self, mock_inputs):
+        Advisor10 = Advisor(4)
+
+        self.assertEqual(Advisor10.players["Michael"].suspect_must_have, {"Miss Peach"})
+        self.assertEqual(Advisor10.players["Michael"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock"})
+
+
 
 
 if __name__ == '__main__':

--- a/src/test/test_advisor.py
+++ b/src/test/test_advisor.py
@@ -466,6 +466,71 @@ class TestAdvisor(unittest.TestCase):
         self.assertEqual(Advisor8.players["secret"].room_possibly_have, {"Kitchen": 1/7, "Trophy Room": 1/7, "Dining Room": 1/7, "Drawing Room": 1/7, 
         "Courtyard": 1/7, "Billiard Room": 1/7, "Studio": 1/7})
 
+    # Adivisor 9
+    # Inherit Advisor8, to validate the otherAgent turn 3 cardgivers with 1 in must-have case, also test a 3 must-have case which do nothing
+    @patch("builtins.input", side_effect = ["7", "Miss Scarlet, Mr. Green, Mrs White", "Candlestick, Knife", "Carriage House, Conservatory","Mia, 7", "Michael, 6","Jane,7",
+    "Next turn", "myself", "Mrs Peacock, Rope, Library", "Mia, Michael, Jane",
+    "Next turn", "myself", "Miss Peach, Horseshoe ,Gazebo", "Michael, Jane, None",
+    "Next turn", "myself", "Mme. Rose, Poison, Gazebo", "None, None, Michael", 
+    "Next turn", "Michael", "Mrs White, Lead Pipe, Fountain", "myself, Mia, Jane",
+    "Next turn", "Jane", "Mrs Peacock, Rope, Conservatory", "Mia, Michael, myself",
+    "Next turn", "Mia", "Miss Scarlet, Horseshoe, Drawing Room", "myself, Jane, Michael",
+    "Query","Player_Summary","Mia","Exit"])
+    def test_Game9(self, mock_inputs):
+        Advisor9 = Advisor(4)
+
+        self.assertEqual(Advisor9.players["Michael"].suspect_must_have, {"Miss Peach"})
+        self.assertEqual(Advisor9.players["Michael"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock"})
+        self.assertEqual(Advisor9.players["Michael"].suspect_possibly_have, {"Colonel Mustard": 2/14, "Professor Plum": 2/14, 
+        "Sgt. Gray": 2/14, "Monsieur Brunette": 2/14,"Mme. Rose":1/2})
+        self.assertEqual(Advisor9.players["Michael"].weapon_must_have, {"Rope"})
+        self.assertEqual(Advisor9.players["Michael"].weapon_must_not_have, {"Candlestick", "Knife", "Horseshoe", "Lead Pipe"})
+        self.assertEqual(Advisor9.players["Michael"].weapon_possibly_have, {"Revolver":2/14, "Wrench": 2/14, "Poison": 1/2})
+        self.assertEqual(Advisor9.players["Michael"].room_must_have, {"Gazebo","Drawing Room"})
+        self.assertEqual(Advisor9.players["Michael"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Fountain"})
+        self.assertEqual(Advisor9.players["Michael"].room_possibly_have, {"Kitchen": 2/14, "Trophy Room": 2/14, "Dining Room": 2/14, 
+        "Courtyard": 2/14, "Billiard Room": 2/14, "Studio": 2/14})
+
+        self.assertEqual(Advisor9.players["Jane"].suspect_must_have,set())
+        self.assertEqual(Advisor9.players["Jane"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Miss Peach", 
+        "Mme. Rose"})
+        self.assertEqual(Advisor9.players["Jane"].suspect_possibly_have, {"Colonel Mustard":5/14, "Professor Plum": 5/14, 
+        "Sgt. Gray": 5/14, "Monsieur Brunette": 5/14})
+        self.assertEqual(Advisor9.players["Jane"].weapon_must_have, {"Horseshoe"})
+        self.assertEqual(Advisor9.players["Jane"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Poison"})
+        self.assertEqual(Advisor9.players["Jane"].weapon_possibly_have, {"Lead Pipe": 1/2, "Revolver": 5/14, "Wrench": 5/14 })
+        self.assertEqual(Advisor9.players["Jane"].room_must_have, {"Library"})
+        self.assertEqual(Advisor9.players["Jane"].room_must_not_have, {"Carriage House", "Conservatory", "Gazebo","Drawing Room"})
+        self.assertEqual(Advisor9.players["Jane"].room_possibly_have, {"Kitchen": 5/14, "Trophy Room":5/14, "Dining Room":5/14, 
+        "Courtyard":5/14, "Fountain":1/2, "Billiard Room":5/14, "Studio":5/14})
+                                                                        
+        self.assertEqual(Advisor9.players["Mia"].suspect_must_have,{"Mrs Peacock"})
+        self.assertEqual(Advisor9.players["Mia"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Miss Peach", "Mme. Rose"})
+        self.assertEqual(Advisor9.players["Mia"].suspect_possibly_have, {"Colonel Mustard": 6/14, "Professor Plum": 6/14, 
+        "Sgt. Gray": 6/14, "Monsieur Brunette": 6/14})
+        self.assertEqual(Advisor9.players["Mia"].weapon_must_have, set())
+        self.assertEqual(Advisor9.players["Mia"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Horseshoe", "Poison"})
+        self.assertEqual(Advisor9.players["Mia"].weapon_possibly_have, {"Lead Pipe": 1/2, "Revolver":6/14, "Wrench":6/14})
+        self.assertEqual(Advisor9.players["Mia"].room_must_have, set())
+        self.assertEqual(Advisor9.players["Mia"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Gazebo", "Drawing Room"})
+        self.assertEqual(Advisor9.players["Mia"].room_possibly_have, {"Kitchen": 6/14, "Trophy Room":6/14, "Dining Room":6/14, 
+        "Courtyard":6/14, "Fountain":1/2, "Billiard Room":6/14, "Studio":6/14})
+
+        self.assertEqual(Advisor9.players["secret"].suspect_must_have,set())
+        self.assertEqual(Advisor9.players["secret"].suspect_must_not_have,{"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Miss Peach"})
+        self.assertEqual(Advisor9.players["secret"].suspect_possibly_have, {"Colonel Mustard": 1/5, "Professor Plum": 1/5, 
+        "Sgt. Gray": 1/5, "Monsieur Brunette": 1/5, "Mme. Rose": 1/2})
+
+        self.assertEqual(Advisor9.players["secret"].weapon_must_have,set())
+        self.assertEqual(Advisor9.players["secret"].weapon_must_not_have,{"Candlestick", "Knife", "Rope", "Horseshoe","Lead Pipe"})
+        self.assertEqual(Advisor9.players["secret"].weapon_possibly_have, {"Revolver": 1/3, "Wrench": 1/3, 
+        "Poison": max(1/3, 1/2)})
+
+        self.assertEqual(Advisor9.players["secret"].room_must_have,set())
+        self.assertEqual(Advisor9.players["secret"].room_must_not_have,{"Carriage House", "Conservatory", "Library", "Gazebo","Fountain", "Drawing Room"})
+        self.assertEqual(Advisor9.players["secret"].room_possibly_have, {"Kitchen": 1/6, "Trophy Room": 1/6, "Dining Room": 1/6, 
+        "Courtyard": 1/6, "Billiard Room": 1/6, "Studio": 1/6})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/test_advisor.py
+++ b/src/test/test_advisor.py
@@ -341,7 +341,7 @@ class TestAdvisor(unittest.TestCase):
     "Next turn", "myself", "Mme. Rose, Poison, Drawing Room", "None, None, Michael",
     "Magnifier", "Mia, Kitchen",
     "Magnifier", "Jane, Horseshoe",
-    "Query","Player_Summary", "Michael","Exit"])
+    "Query","Log","Exit"])
     def test_Game7(self, mock_inputs):
         Advisor7 = Advisor(4)
 

--- a/src/test/test_advisor.py
+++ b/src/test/test_advisor.py
@@ -398,5 +398,74 @@ class TestAdvisor(unittest.TestCase):
         self.assertEqual(Advisor7.players["secret"].room_possibly_have,{"Trophy Room": 1/6, "Dining Room": 1/6, 
         "Courtyard": 1/6, "Fountain": 1/6, "Billiard Room": 1/6, "Studio": 1/6})
 
+
+    
+
+    # Adivisor 8
+    # Inherit Advisor4, to validate the otherAgent turn 3 cardgivers with 1 in must-have case, also test a 3 must-have case which do nothing
+    @patch("builtins.input", side_effect = ["7", "Miss Scarlet, Mr. Green, Mrs White", "Candlestick, Knife", "Carriage House, Conservatory","Mia, 7", "Michael, 6","Jane,7",
+    "Next turn", "myself", "Mrs Peacock, Rope, Library", "Mia, Michael, Jane",
+    "Next turn", "myself", "Miss Peach, Horseshoe ,Gazebo", "Michael, Jane, None",
+    "Next turn", "myself", "Mme. Rose, Poison, Gazebo", "None, None, Michael", 
+    "Next turn", "Michael", "Mrs White, Lead Pipe, Fountain", "myself, Mia, Jane",
+    "Next turn", "Jane", "Mrs Peacock, Rope, Conservatory", "Mia, Michael, myself",
+    "Query","Player_Summary","Michael","Exit"])
+    def test_Game8(self, mock_inputs):
+        Advisor8 = Advisor(4)
+
+        self.assertEqual(Advisor8.players["Michael"].suspect_must_have, {"Miss Peach"})
+        self.assertEqual(Advisor8.players["Michael"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock"})
+        self.assertEqual(Advisor8.players["Michael"].suspect_possibly_have, {"Colonel Mustard": 3/15, "Professor Plum": 3/15, 
+        "Sgt. Gray": 3/15, "Monsieur Brunette": 3/15,"Mme. Rose":1/2})
+        self.assertEqual(Advisor8.players["Michael"].weapon_must_have, {"Rope"})
+        self.assertEqual(Advisor8.players["Michael"].weapon_must_not_have, {"Candlestick", "Knife", "Horseshoe", "Lead Pipe"})
+        self.assertEqual(Advisor8.players["Michael"].weapon_possibly_have, {"Revolver": 3/15,
+        "Wrench": 3/15, "Poison": 1/2})
+        self.assertEqual(Advisor8.players["Michael"].room_must_have, {"Gazebo"})
+        self.assertEqual(Advisor8.players["Michael"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Fountain"})
+        self.assertEqual(Advisor8.players["Michael"].room_possibly_have, {"Kitchen": 3/15, "Trophy Room": 3/15, "Dining Room": 3/15, 
+        "Drawing Room": 3/15, "Courtyard": 3/15, "Billiard Room": 3/15, "Studio": 3/15})
+
+        self.assertEqual(Advisor8.players["Jane"].suspect_must_have,set())
+        self.assertEqual(Advisor8.players["Jane"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Miss Peach", 
+        "Mme. Rose"})
+        self.assertEqual(Advisor8.players["Jane"].suspect_possibly_have, {"Colonel Mustard":5/15, "Professor Plum": 5/15, 
+        "Sgt. Gray": 5/15, "Monsieur Brunette": 5/15})
+        self.assertEqual(Advisor8.players["Jane"].weapon_must_have, {"Horseshoe"})
+        self.assertEqual(Advisor8.players["Jane"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Poison"})
+        self.assertEqual(Advisor8.players["Jane"].weapon_possibly_have, {"Lead Pipe": 1/2, "Revolver": 5/15, "Wrench": 5/15 })
+        self.assertEqual(Advisor8.players["Jane"].room_must_have, {"Library"})
+        self.assertEqual(Advisor8.players["Jane"].room_must_not_have, {"Carriage House", "Conservatory", "Gazebo"})
+        self.assertEqual(Advisor8.players["Jane"].room_possibly_have, {"Kitchen": 5/15, "Trophy Room":5/15, "Dining Room":5/15, 
+        "Drawing Room":5/15, "Courtyard":5/15, "Fountain":1/2, "Billiard Room":5/15, "Studio":5/15})
+                                                                        
+        self.assertEqual(Advisor8.players["Mia"].suspect_must_have,{"Mrs Peacock"})
+        self.assertEqual(Advisor8.players["Mia"].suspect_must_not_have, {"Miss Scarlet", "Mr. Green", "Mrs White", "Miss Peach", "Mme. Rose"})
+        self.assertEqual(Advisor8.players["Mia"].suspect_possibly_have, {"Colonel Mustard": 6/15, "Professor Plum": 6/15, 
+        "Sgt. Gray": 6/15, "Monsieur Brunette": 6/15})
+        self.assertEqual(Advisor8.players["Mia"].weapon_must_have, set())
+        self.assertEqual(Advisor8.players["Mia"].weapon_must_not_have, {"Candlestick", "Knife", "Rope", "Horseshoe", "Poison"})
+        self.assertEqual(Advisor8.players["Mia"].weapon_possibly_have, {"Lead Pipe": 1/2, "Revolver":6/15, "Wrench":6/15})
+        self.assertEqual(Advisor8.players["Mia"].room_must_have, set())
+        self.assertEqual(Advisor8.players["Mia"].room_must_not_have, {"Carriage House", "Conservatory", "Library", "Gazebo"})
+        self.assertEqual(Advisor8.players["Mia"].room_possibly_have, {"Kitchen": 6/15, "Trophy Room":6/15, "Dining Room":6/15, 
+        "Drawing Room":6/15, "Courtyard":6/15, "Fountain":1/2, "Billiard Room":6/15, "Studio":6/15})
+
+        self.assertEqual(Advisor8.players["secret"].suspect_must_have,set())
+        self.assertEqual(Advisor8.players["secret"].suspect_must_not_have,{"Miss Scarlet", "Mr. Green", "Mrs White", "Mrs Peacock", "Miss Peach"})
+        self.assertEqual(Advisor8.players["secret"].suspect_possibly_have, {"Colonel Mustard": 1/5, "Professor Plum": 1/5, 
+        "Sgt. Gray": 1/5, "Monsieur Brunette": 1/5, "Mme. Rose": 1/2})
+
+        self.assertEqual(Advisor8.players["secret"].weapon_must_have,set())
+        self.assertEqual(Advisor8.players["secret"].weapon_must_not_have,{"Candlestick", "Knife", "Rope", "Horseshoe","Lead Pipe"})
+        self.assertEqual(Advisor8.players["secret"].weapon_possibly_have, {"Revolver": 1/3, "Wrench": 1/3, 
+        "Poison": max(1/3, 1/2)})
+
+        self.assertEqual(Advisor8.players["secret"].room_must_have,set())
+        self.assertEqual(Advisor8.players["secret"].room_must_not_have,{"Carriage House", "Conservatory", "Library", "Gazebo","Fountain"})
+        self.assertEqual(Advisor8.players["secret"].room_possibly_have, {"Kitchen": 1/7, "Trophy Room": 1/7, "Dining Room": 1/7, "Drawing Room": 1/7, 
+        "Courtyard": 1/7, "Billiard Room": 1/7, "Studio": 1/7})
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/utils/agentAIUtils.py
+++ b/src/utils/agentAIUtils.py
@@ -286,21 +286,24 @@ def otherAgent_turnUpdate_3cardsCase(claimer, claim_suspect, claim_weapon, claim
             del playerHashmap[thePlayer].room_possibly_have[claim_room]
             for twoOther in [SuspectMustHavePlayer, WeaponMustHavePlayer]:
                 playerHashmap[twoOther].update_room_must_not_have(claim_room)
-                del playerHashmap[twoOther].room_possiblly_have[claim_room]
+                if claim_room in playerHashmap[twoOther].room_possibly_have.keys():
+                    del playerHashmap[twoOther].room_possibly_have[claim_room]
         elif SuspectMustHavePlayer != None and RoomMustHavePlayer != None:
             thePlayer = [x for x in card_givers if x!= SuspectMustHavePlayer and x!= RoomMustHavePlayer][0]
             playerHashmap[thePlayer].udpate_weapon_must_have(claim_weapon)
             del playerHashmap[thePlayer].weapon_possibly_have[claim_weapon]
             for twoOther in [SuspectMustHavePlayer, RoomMustHavePlayer]:
                 playerHashmap[twoOther].update_weapon_must_not_have(claim_weapon)
-                del playerHashmap[twoOther].weapon_possiblly_have[claim_weapon]
+                if claim_weapon in playerHashmap[twoOther].weapon_possibly_have.keys():
+                    del playerHashmap[twoOther].weapon_possibly_have[claim_weapon]
         elif WeaponMustHavePlayer != None and RoomMustHavePlayer != None:
             thePlayer = [x for x in card_givers if x!= WeaponMustHavePlayer and x!= RoomMustHavePlayer][0]
             playerHashmap[thePlayer].udpate_suspect_must_have(claim_suspect)
             del playerHashmap[thePlayer].suspect_possibly_have[claim_suspect]
             for twoOther in [WeaponMustHavePlayer, RoomMustHavePlayer]:
                 playerHashmap[twoOther].update_suspect_must_not_have(claim_suspect)
-                del playerHashmap[twoOther].suspect_possiblly_have[claim_suspect]
+                if claim_suspect in playerHashmap[twoOther].suspect_possibly_have.keys():
+                    del playerHashmap[twoOther].suspect_possibly_have[claim_suspect]
         
     elif cardsInMustHave == 1:
         ## figure out which card is the one in must-have

--- a/src/utils/agentAIUtils.py
+++ b/src/utils/agentAIUtils.py
@@ -386,11 +386,11 @@ def otherAgent_turnUpdate_1cardsCase(claimer, claim_suspect, claim_weapon, claim
     ## deal with weapon, check how many among the 3 potential got claim_weapon in must-not-have
     player_with_claim_weapon_in_must_not_have = get_potential_must_not_have_helper(claim_weapon, playerHashmap, potential_players)
     complement_set_player_claim_weapon = [x for x in potential_players if x not in player_with_claim_weapon_in_must_not_have and x != player_must_have_claim_weapon]
-    print("potential player: ",potential_players)
-    print("player_with_claim_weapon_in_must_not_have: ",player_with_claim_weapon_in_must_not_have)
-    print("player_must_have_claim_weapon: ",player_must_have_claim_weapon)
-    print("len(complement_set_player_claim_weapon): ", len(complement_set_player_claim_weapon))
-    print("complement_set_player_claim_weapon: ", complement_set_player_claim_weapon)
+    # print("potential player: ",potential_players)
+    # print("player_with_claim_weapon_in_must_not_have: ",player_with_claim_weapon_in_must_not_have)
+    # print("player_must_have_claim_weapon: ",player_must_have_claim_weapon)
+    # print("len(complement_set_player_claim_weapon): ", len(complement_set_player_claim_weapon))
+    # print("complement_set_player_claim_weapon: ", complement_set_player_claim_weapon)
     if len(complement_set_player_claim_weapon) == 1:
         player_to_update = complement_set_player_claim_weapon[0]
         playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_weapon)

--- a/src/utils/agentAIUtils.py
+++ b/src/utils/agentAIUtils.py
@@ -357,14 +357,11 @@ def first_True(array):
 def otherAgent_turnUpdate_1cardsCase(claimer, claim_suspect, claim_weapon, claim_room, card_giver, playerHashmap):
     potential_players = {"secret", claimer, card_giver[0]}
     ## check how many of claim objects are in must-have
-    # player_must_have_claim_suspect = search_in_must_have(playerHashmap, claim_suspect, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
-    # player_must_have_claim_weapon = search_in_must_have(playerHashmap, claim_weapon, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
-    # player_must_have_claim_room = search_in_must_have(playerHashmap, claim_room, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
-    # total_in_must_have = 0
-    # for i in [player_must_have_claim_suspect, player_must_have_claim_weapon, player_must_have_claim_room]:
-    #     if i != "None":
-    #         total_in_must_have +=1
-    ## remove the 3 cards from non_related_players first
+    player_must_have_claim_suspect = search_in_must_have(playerHashmap, claim_suspect, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
+    player_must_have_claim_weapon = search_in_must_have(playerHashmap, claim_weapon, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
+    player_must_have_claim_room = search_in_must_have(playerHashmap, claim_room, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
+
+    # remove the 3 cards from non_related_players first
     for non_related_players in [x for x in playerHashmap.keys() if x not in potential_players]:
         playerHashmap[non_related_players].move_ele_possibly_to_must_not_have(claim_suspect)
         playerHashmap[non_related_players].move_ele_possibly_to_must_not_have(claim_weapon)
@@ -372,7 +369,7 @@ def otherAgent_turnUpdate_1cardsCase(claimer, claim_suspect, claim_weapon, claim
 
     ## deal with suspect, check how many among the 3 potential got claim_suspect in must-not-have
     player_with_claim_suspect_in_must_not_have = get_potential_must_not_have_helper(claim_suspect, playerHashmap, potential_players)
-    complement_set_player_claim_suspect = [x for x in potential_players if x not in player_with_claim_suspect_in_must_not_have]
+    complement_set_player_claim_suspect = [x for x in potential_players if x not in player_with_claim_suspect_in_must_not_have and x != player_must_have_claim_suspect]
     if len(complement_set_player_claim_suspect) == 1:
         player_to_update = complement_set_player_claim_suspect[0]
         playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_suspect)
@@ -380,13 +377,20 @@ def otherAgent_turnUpdate_1cardsCase(claimer, claim_suspect, claim_weapon, claim
         player_to_update = complement_set_player_claim_suspect
         for i in player_to_update:
             playerHashmap[i].update_suspect_possibly_have(claim_suspect, 1/2)
-    else: # len(complement_set_player_claim_suspect) == 3:
+    elif len(complement_set_player_claim_suspect) == 3:
         for i in potential_players:
             playerHashmap[i].update_suspect_possibly_have(claim_suspect, 1/3)
+    else: #len(complement_set_player_claim_suspect) == 0
+        pass
     
     ## deal with weapon, check how many among the 3 potential got claim_weapon in must-not-have
     player_with_claim_weapon_in_must_not_have = get_potential_must_not_have_helper(claim_weapon, playerHashmap, potential_players)
-    complement_set_player_claim_weapon = [x for x in potential_players if x not in player_with_claim_weapon_in_must_not_have]
+    complement_set_player_claim_weapon = [x for x in potential_players if x not in player_with_claim_weapon_in_must_not_have and x != player_must_have_claim_weapon]
+    print("potential player: ",potential_players)
+    print("player_with_claim_weapon_in_must_not_have: ",player_with_claim_weapon_in_must_not_have)
+    print("player_must_have_claim_weapon: ",player_must_have_claim_weapon)
+    print("len(complement_set_player_claim_weapon): ", len(complement_set_player_claim_weapon))
+    print("complement_set_player_claim_weapon: ", complement_set_player_claim_weapon)
     if len(complement_set_player_claim_weapon) == 1:
         player_to_update = complement_set_player_claim_weapon[0]
         playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_weapon)
@@ -394,13 +398,15 @@ def otherAgent_turnUpdate_1cardsCase(claimer, claim_suspect, claim_weapon, claim
         player_to_update = complement_set_player_claim_weapon
         for i in player_to_update:
             playerHashmap[i].update_weapon_possibly_have(claim_weapon, 1/2)
-    else: # len(complement_set_player_claim_weapon) == 3:
+    elif len(complement_set_player_claim_weapon) == 3:
         for i in potential_players:
             playerHashmap[i].update_weapon_possibly_have(claim_weapon, 1/3)
+    else: #len(complement_set_player_claim_weapon) == 0
+        pass 
 
     ## deal with room, check how many among the 3 potential got claim_room in must-not-have
     player_with_claim_room_in_must_not_have = get_potential_must_not_have_helper(claim_room, playerHashmap, potential_players)
-    complement_set_player_claim_room = [x for x in potential_players if x not in player_with_claim_room_in_must_not_have]
+    complement_set_player_claim_room = [x for x in potential_players if x not in player_with_claim_room_in_must_not_have and x != player_must_have_claim_room]
     if len(complement_set_player_claim_room) == 1:
         player_to_update = complement_set_player_claim_room[0]
         playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_room)
@@ -408,9 +414,11 @@ def otherAgent_turnUpdate_1cardsCase(claimer, claim_suspect, claim_weapon, claim
         player_to_update = complement_set_player_claim_room
         for i in player_to_update:
             playerHashmap[i].update_room_possibly_have(claim_room, 1/2)
-    else: # len(complement_set_player_claim_room) == 3:
+    elif len(complement_set_player_claim_room) == 3:
         for i in potential_players:
             playerHashmap[i].update_room_possibly_have(claim_room, 1/3)
+    else: #len(complement_set_player_claim_room) == 0
+        pass
         
 
 # ========

--- a/src/utils/agentAIUtils.py
+++ b/src/utils/agentAIUtils.py
@@ -150,23 +150,15 @@ def myself_turn_players_update(ObjectDealing ,not_in_must_have, card_giver, card
 # ===============
 # Make necessary inference and update to secret agent after each round's update
 # ===============
-def secret_infer_helper(ObjectDealing, LIST_XXX, playersHashmap):
+def secret_infer_helper(ObjectDealing, LIST_XXX, playersHashmap, numberOfPlayers):
     if ObjectDealing == "suspect":
         if len(playersHashmap["secret"].suspect_must_have) == 0:
             suspect_found = "None"
             for suspect_poss in LIST_XXX:
-                flag = "This One"
-                for player in [x for x in playersHashmap.keys() if x != "secret"]:
-                    if suspect_poss in playersHashmap[player].suspect_must_not_have:
-                        continue
-                    else:
-                        flag = "Not this One"
-                        break
-                if flag == "This One":
+                results = [playersHashmap[x].check_in_must_not_have(suspect_poss) for x in playersHashmap.keys() if x != "secret"]
+                in_all_other_must_not_have = True if sum(results) == numberOfPlayers else False
+                if in_all_other_must_not_have:
                     suspect_found = suspect_poss
-                    break
-                elif flag == "Not this One":
-                    continue
             # if None is found, do nothing, otherwise, make inference
             if suspect_found == "None":
                 pass
@@ -178,22 +170,19 @@ def secret_infer_helper(ObjectDealing, LIST_XXX, playersHashmap):
                 for ele in playersHashmap["secret"].suspect_possibly_have.keys():
                     playersHashmap["secret"].update_suspect_must_not_have(ele)
                 playersHashmap["secret"].suspect_possibly_have = {}
+        else: ## when something is added to suspect_must_have in seceret, clean the possibly set
+            if len(playersHashmap["secret"].suspect_possibly_have):
+                for ele in playersHashmap["secret"].suspect_possibly_have.keys():
+                    playersHashmap["secret"].update_suspect_must_not_have(ele)
+                playersHashmap["secret"].suspect_possibly_have = {}
     elif ObjectDealing == "weapon":
         if len(playersHashmap["secret"].weapon_must_have) == 0:
             weapon_found = "None"
             for weapon_poss in LIST_XXX:
-                flag = "This One"
-                for player in [x for x in playersHashmap.keys() if x != "secret"]:
-                    if weapon_poss in playersHashmap[player].weapon_must_not_have:
-                        continue
-                    else:
-                        flag = "Not this One"
-                        break
-                if flag == "This One":
+                results = [playersHashmap[x].check_in_must_not_have(weapon_poss) for x in playersHashmap.keys() if x != "secret"]
+                in_all_other_must_not_have = True if sum(results) == numberOfPlayers else False
+                if in_all_other_must_not_have:
                     weapon_found = weapon_poss
-                    break
-                elif flag == "Not this One":
-                    continue
             # if None is found, do nothing, otherwise, make inference
             if weapon_found == "None":
                 pass
@@ -205,22 +194,19 @@ def secret_infer_helper(ObjectDealing, LIST_XXX, playersHashmap):
                 for ele in playersHashmap["secret"].weapon_possibly_have.keys():
                     playersHashmap["secret"].update_weapon_must_not_have(ele)
                 playersHashmap["secret"].weapon_possibly_have = {}
+        else: ## when something is added to weapon_must_have in seceret, clean the possibly set
+            if len(playersHashmap["secret"].weapon_possibly_have):
+                for ele in playersHashmap["secret"].weapon_possibly_have.keys():
+                    playersHashmap["secret"].update_weapon_must_not_have(ele)
+                playersHashmap["secret"].weapon_possibly_have = {}
     elif ObjectDealing == "room":
         if len(playersHashmap["secret"].room_must_have) == 0:
             room_found = "None"
             for room_poss in LIST_XXX:
-                flag = "This One"
-                for player in [x for x in playersHashmap.keys() if x != "secret"]:
-                    if room_poss in playersHashmap[player].room_must_not_have:
-                        continue
-                    else:
-                        flag = "Not this One"
-                        break
-                if flag == "This One":
+                results = [playersHashmap[x].check_in_must_not_have(room_poss) for x in playersHashmap.keys() if x != "secret"]
+                in_all_other_must_not_have = True if sum(results) == numberOfPlayers else False
+                if in_all_other_must_not_have:
                     room_found = room_poss
-                    break
-                elif flag == "Not this One":
-                    continue
             # if None is found, do nothing, otherwise, make inference
             if room_found == "None":
                 pass
@@ -229,6 +215,11 @@ def secret_infer_helper(ObjectDealing, LIST_XXX, playersHashmap):
                 playersHashmap["secret"].update_room_must_have(room_found)
                 del playersHashmap["secret"].room_possibly_have[room_found]
                 ## clean up the rest of possibly set, and move them to must-not-have class
+                for ele in playersHashmap["secret"].room_possibly_have.keys():
+                    playersHashmap["secret"].update_room_must_not_have(ele)
+                playersHashmap["secret"].room_possibly_have = {}
+        else: ## when something is added to room_must_have in seceret, clean the possibly set
+            if len(playersHashmap["secret"].room_possibly_have):
                 for ele in playersHashmap["secret"].room_possibly_have.keys():
                     playersHashmap["secret"].update_room_must_not_have(ele)
                 playersHashmap["secret"].room_possibly_have = {}

--- a/src/utils/agentAIUtils.py
+++ b/src/utils/agentAIUtils.py
@@ -357,13 +357,13 @@ def first_True(array):
 def otherAgent_turnUpdate_1cardsCase(claimer, claim_suspect, claim_weapon, claim_room, card_giver, playerHashmap):
     potential_players = {"secret", claimer, card_giver[0]}
     ## check how many of claim objects are in must-have
-    player_must_have_claim_suspect = search_in_must_have(playerHashmap, claim_suspect, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
-    player_must_have_claim_weapon = search_in_must_have(playerHashmap, claim_weapon, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
-    player_must_have_claim_room = search_in_must_have(playerHashmap, claim_room, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
-    total_in_must_have = 0
-    for i in [player_must_have_claim_suspect, player_must_have_claim_weapon, player_must_have_claim_room]:
-        if i != "None":
-            total_in_must_have +=1
+    # player_must_have_claim_suspect = search_in_must_have(playerHashmap, claim_suspect, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
+    # player_must_have_claim_weapon = search_in_must_have(playerHashmap, claim_weapon, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
+    # player_must_have_claim_room = search_in_must_have(playerHashmap, claim_room, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
+    # total_in_must_have = 0
+    # for i in [player_must_have_claim_suspect, player_must_have_claim_weapon, player_must_have_claim_room]:
+    #     if i != "None":
+    #         total_in_must_have +=1
     ## remove the 3 cards from non_related_players first
     for non_related_players in [x for x in playerHashmap.keys() if x not in potential_players]:
         playerHashmap[non_related_players].move_ele_possibly_to_must_not_have(claim_suspect)

--- a/src/utils/agentAIUtils.py
+++ b/src/utils/agentAIUtils.py
@@ -247,7 +247,9 @@ def otherAgent_infer_helper(ObjectDealing, playerHashmap, playerName, playerQuan
                 del playerHashmap[playerName].room_possibly_have[ele]
 
 
-
+# ===============
+# Method to handle when other player makes a claim and there's 3 cardgivers
+# ===============
 def otherAgent_turnUpdate_3cardsCase(claimer, claim_suspect, claim_weapon, claim_room, card_givers, playerHashmap):
     """
     card_givers will always be an array with 3 elements
@@ -326,6 +328,69 @@ def otherAgent_turnUpdate_3cardsCase(claimer, claim_suspect, claim_weapon, claim
             playerHashmap[related_player].update_weapon_possibly_have(claim_weapon, 1/3)
             playerHashmap[related_player].update_room_possibly_have(claim_room, 1/3)
 
+
+# ===============
+# Method to handle when other player makes a claim and there's 0 cardgivers
+# ===============
+def otherAgent_turnUpdate_0cardsCase(claimer, claim_suspect, claim_weapon, claim_room, playerHashmap):
+    """
+    There's always no card_givers in this case
+    """
+    ## Handle claim_suspect, players other than secret or claimer must not have claim_suspect, can be optimzed here TODO 
+    for otherPlayer in [x for x in playerHashmap.keys() if x != claimer and x != "secret"]:
+        playerHashmap[otherPlayer].move_ele_possibly_to_must_not_have(claim_suspect)
+    ## if claim_suspect in secret or claimer's must-have, do nothing, ADD cheat score to claimer HERE TODO
+    if claim_suspect in playerHashmap["secret"].suspect_must_have:
+        pass  ## do nothing
+    elif claim_suspect in playerHashmap["secret"].suspect_must_not_have:
+        ## move claim_suspect to claimer's suspect_must_have
+        playerHashmap[claimer].move_ele_possibly_to_must_have(claim_suspect)
+    elif claim_suspect in playerHashmap[claimer].suspect_must_have:
+        pass ## do nothing
+    elif claim_suspect in playerHashmap[claimer].suspect_must_not_have:
+        ## move claim_suspect to secret's suspect_must_have
+        playerHashmap["secret"].move_ele_possibly_to_must_have(claim_suspect)
+    else:  ## update claimer and secret's possilby have
+        playerHashmap[claimer].update_suspect_possibly_have(claim_suspect, 1/2)
+        playerHashmap["secret"].update_suspect_possibly_have(claim_suspect, 1/2)
+
+    
+    ## Handle claim_weapon, players other than secret or claimer must not have claim_weapon, can be optimzed here TODO 
+    for otherPlayer in [x for x in playerHashmap.keys() if x != claimer and x != "secret"]:
+        playerHashmap[otherPlayer].move_ele_possibly_to_must_not_have(claim_weapon)
+    ## if claim_weapon in secret or claimer's must-have, do nothing, ADD cheat score to claimer HERE TODO
+    if claim_weapon in playerHashmap["secret"].weapon_must_have:
+        pass  ## do nothing
+    elif claim_weapon in playerHashmap["secret"].weapon_must_not_have:
+        ## move claim_weapon to claimer's weapon_must_have
+        playerHashmap[claimer].move_ele_possibly_to_must_have(claim_weapon)
+    elif claim_weapon in playerHashmap[claimer].weapon_must_have:
+        pass ## do nothing
+    elif claim_weapon in playerHashmap[claimer].weapon_must_not_have:
+        ## move claim_weapon to secret's weapon_must_have
+        playerHashmap["secret"].move_ele_possibly_to_must_have(claim_weapon)
+    else:  ## update claimer and secret's possilby have
+        playerHashmap[claimer].update_weapon_possibly_have(claim_weapon, 1/2)
+        playerHashmap["secret"].update_weapon_possibly_have(claim_weapon, 1/2)
+
+    
+    ## Handle claim_room, players other than secret or claimer must not have claim_room, can be optimzed here TODO 
+    for otherPlayer in [x for x in playerHashmap.keys() if x != claimer and x != "secret"]:
+        playerHashmap[otherPlayer].move_ele_possibly_to_must_not_have(claim_room)
+    ## if claim_room in secret or claimer's must-have, do nothing, ADD cheat score to claimer HERE TODO
+    if claim_room in playerHashmap["secret"].room_must_have:
+        pass  ## do nothing
+    elif claim_room in playerHashmap["secret"].room_must_not_have:
+        ## move claim_room to claimer's room_must_have
+        playerHashmap[claimer].move_ele_possibly_to_must_have(claim_room)
+    elif claim_room in playerHashmap[claimer].room_must_have:
+        pass ## do nothing
+    elif claim_room in playerHashmap[claimer].room_must_not_have:
+        ## move claim_room to secret's room_must_have
+        playerHashmap["secret"].move_ele_possibly_to_must_have(claim_room)
+    else:  ## update claimer and secret's possilby have
+        playerHashmap[claimer].update_room_possibly_have(claim_room, 1/2)
+        playerHashmap["secret"].update_room_possibly_have(claim_room, 1/2)
 
 
 ## A helper method for otherturn handler

--- a/src/utils/agentAIUtils.py
+++ b/src/utils/agentAIUtils.py
@@ -281,21 +281,24 @@ def otherAgent_turnUpdate_3cardsCase(claimer, claim_suspect, claim_weapon, claim
         pass
     elif cardsInMustHave == 2:
         if SuspectMustHavePlayer != None and WeaponMustHavePlayer != None:
-            playerHashmap[card_givers[2]].update_room_must_have(claim_room)
-            del playerHashmap[card_givers[2]].room_possibly_have[claim_room]
-            for twoOther in card_givers[0:2]:
+            thePlayer = [x for x in card_givers if x!= SuspectMustHavePlayer and x!= WeaponMustHavePlayer][0]
+            playerHashmap[thePlayer].update_room_must_have(claim_room)
+            del playerHashmap[thePlayer].room_possibly_have[claim_room]
+            for twoOther in [SuspectMustHavePlayer, WeaponMustHavePlayer]:
                 playerHashmap[twoOther].update_room_must_not_have(claim_room)
                 del playerHashmap[twoOther].room_possiblly_have[claim_room]
         elif SuspectMustHavePlayer != None and RoomMustHavePlayer != None:
-            playerHashmap[card_givers[1]].udpate_weapon_must_have(claim_weapon)
-            del playerHashmap[card_givers[1]].weapon_possibly_have[claim_weapon]
-            for twoOther in [x for x in card_givers if x != card_givers[1]]:
+            thePlayer = [x for x in card_givers if x!= SuspectMustHavePlayer and x!= RoomMustHavePlayer][0]
+            playerHashmap[thePlayer].udpate_weapon_must_have(claim_weapon)
+            del playerHashmap[thePlayer].weapon_possibly_have[claim_weapon]
+            for twoOther in [SuspectMustHavePlayer, RoomMustHavePlayer]:
                 playerHashmap[twoOther].update_weapon_must_not_have(claim_weapon)
                 del playerHashmap[twoOther].weapon_possiblly_have[claim_weapon]
         elif WeaponMustHavePlayer != None and RoomMustHavePlayer != None:
-            playerHashmap[card_givers[0]].udpate_suspect_must_have(claim_suspect)
-            del playerHashmap[card_givers[0]].suspect_possibly_have[claim_suspect]
-            for twoOther in [x for x in card_givers[1:]]:
+            thePlayer = [x for x in card_givers if x!= WeaponMustHavePlayer and x!= RoomMustHavePlayer][0]
+            playerHashmap[thePlayer].udpate_suspect_must_have(claim_suspect)
+            del playerHashmap[thePlayer].suspect_possibly_have[claim_suspect]
+            for twoOther in [WeaponMustHavePlayer, RoomMustHavePlayer]:
                 playerHashmap[twoOther].update_suspect_must_not_have(claim_suspect)
                 del playerHashmap[twoOther].suspect_possiblly_have[claim_suspect]
         

--- a/src/utils/agentAIUtils.py
+++ b/src/utils/agentAIUtils.py
@@ -2,7 +2,9 @@
 
 from logging import raiseExceptions
 
-
+# ===============
+# A global search method that check if item_checking is in any of player's must have
+# ===============
 def search_in_must_have(playersHashMap, item_checking, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM):
     '''
     return who has the item or None if no one has it.
@@ -31,6 +33,9 @@ def search_in_must_have(playersHashMap, item_checking, LIST_SUSPECT, LIST_WEAPON
     return "None"
 
 
+# ===============
+# General update to the hashmaps in myself turn cases
+# ===============
 def myself_turn_players_update(ObjectDealing ,not_in_must_have, card_giver, card_giver_list, playersHashmap, claim_object, cards_received):
 
     if ObjectDealing == "suspect":
@@ -136,9 +141,9 @@ def myself_turn_players_update(ObjectDealing ,not_in_must_have, card_giver, card
             pass
 
 
-
-
-
+# ===============
+# Make necessary inference and update to secret agent after each round's update
+# ===============
 def secret_infer_helper(ObjectDealing, LIST_XXX, playersHashmap):
     if ObjectDealing == "suspect":
         if len(playersHashmap["secret"].suspect_must_have) == 0:
@@ -223,6 +228,9 @@ def secret_infer_helper(ObjectDealing, LIST_XXX, playersHashmap):
                 playersHashmap["secret"].room_possibly_have = {}
 
 
+# ===============
+# Make necessary inference and update to otherAgent after each round's update
+# ===============
 def otherAgent_infer_helper(ObjectDealing, playerHashmap, playerName, playerQuantity):
     if ObjectDealing == "suspect":
         for ele in playerHashmap[playerName].suspect_possibly_have.keys():

--- a/src/utils/agentAIUtils.py
+++ b/src/utils/agentAIUtils.py
@@ -369,53 +369,48 @@ def otherAgent_turnUpdate_1cardsCase(claimer, claim_suspect, claim_weapon, claim
         playerHashmap[non_related_players].move_ele_possibly_to_must_not_have(claim_suspect)
         playerHashmap[non_related_players].move_ele_possibly_to_must_not_have(claim_weapon)
         playerHashmap[non_related_players].move_ele_possibly_to_must_not_have(claim_room)
-    if total_in_must_have == 3:
-        pass # do nothing
-    elif total_in_must_have == 0:
-        ## deal with suspect, check how many among the 3 potential got claim_suspect in must-not-have
-        player_with_claim_suspect_in_must_not_have = get_potential_must_not_have_helper(claim_suspect, playerHashmap, potential_players)
-        if len(player_with_claim_suspect_in_must_not_have) == 3:
-            raiseExceptions("Impossible to happen, someone violates the rule")
-        elif len(player_with_claim_suspect_in_must_not_have) == 2:  ## if two out of 3 potential are in must-not-have, make direct inference 
-            player_to_update = [x for x in potential_players if x not in player_with_claim_suspect_in_must_not_have][0]
-            playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_suspect)
-        elif len(player_with_claim_suspect_in_must_not_have) == 1:
-            player_to_update = [x for x in potential_players if x not in player_with_claim_suspect_in_must_not_have]
-            for i in player_to_update:
-                playerHashmap[i].update_suspect_possibly_have(claim_suspect, 1/2)
-        else: # len(player_with_claim_suspect_in_must_not_have) == 0:
-            for i in potential_players:
-                playerHashmap[i].update_suspect_possibly_have(claim_suspect, 1/3)
-        ## same logic for weapon and room
-        ## deal with weapon, check how many among the 3 potential got claim_weapon in must-not-have
-        player_with_claim_weapon_in_must_not_have = get_potential_must_not_have_helper(claim_weapon, playerHashmap, potential_players)
-        if len(player_with_claim_weapon_in_must_not_have) == 3:
-            raiseExceptions("Impossible to happen, someone violates the rule")
-        elif len(player_with_claim_weapon_in_must_not_have) == 2:  ## if two out of 3 potential are in must-not-have, make direct inference 
-            player_to_update = [x for x in potential_players if x not in player_with_claim_weapon_in_must_not_have][0]
-            playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_weapon)
-        elif len(player_with_claim_weapon_in_must_not_have) == 1:
-            player_to_update = [x for x in potential_players if x not in player_with_claim_weapon_in_must_not_have]
-            for i in player_to_update:
-                playerHashmap[i].update_weapon_possibly_have(claim_weapon, 1/2)
-        else: # len(player_with_claim_weapon_in_must_not_have) == 0:
-            for i in potential_players:
-                playerHashmap[i].update_weapon_possibly_have(claim_weapon, 1/3)
-        ## deal with room, check how many among the 3 potential got claim_room in must-not-have
-        player_with_claim_room_in_must_not_have = get_potential_must_not_have_helper(claim_room, playerHashmap, potential_players)
-        if len(player_with_claim_room_in_must_not_have) == 3:
-            raiseExceptions("Impossible to happen, someone violates the rule")
-        elif len(player_with_claim_room_in_must_not_have) == 2:  ## if two out of 3 potential are in must-not-have, make direct inference 
-            player_to_update = [x for x in potential_players if x not in player_with_claim_room_in_must_not_have][0]
-            playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_room)
-        elif len(player_with_claim_room_in_must_not_have) == 1:
-            player_to_update = [x for x in potential_players if x not in player_with_claim_room_in_must_not_have]
-            for i in player_to_update:
-                playerHashmap[i].update_room_possibly_have(claim_room, 1/2)
-        else: # len(player_with_claim_room_in_must_not_have) == 0:
-            for i in potential_players:
-                playerHashmap[i].update_room_possibly_have(claim_room, 1/3)
 
+    ## deal with suspect, check how many among the 3 potential got claim_suspect in must-not-have
+    player_with_claim_suspect_in_must_not_have = get_potential_must_not_have_helper(claim_suspect, playerHashmap, potential_players)
+    complement_set_player_claim_suspect = [x for x in potential_players if x not in player_with_claim_suspect_in_must_not_have]
+    if len(complement_set_player_claim_suspect) == 1:
+        player_to_update = complement_set_player_claim_suspect[0]
+        playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_suspect)
+    elif len(complement_set_player_claim_suspect) == 2:
+        player_to_update = complement_set_player_claim_suspect
+        for i in player_to_update:
+            playerHashmap[i].update_suspect_possibly_have(claim_suspect, 1/2)
+    else: # len(complement_set_player_claim_suspect) == 3:
+        for i in potential_players:
+            playerHashmap[i].update_suspect_possibly_have(claim_suspect, 1/3)
+    
+    ## deal with weapon, check how many among the 3 potential got claim_weapon in must-not-have
+    player_with_claim_weapon_in_must_not_have = get_potential_must_not_have_helper(claim_weapon, playerHashmap, potential_players)
+    complement_set_player_claim_weapon = [x for x in potential_players if x not in player_with_claim_weapon_in_must_not_have]
+    if len(complement_set_player_claim_weapon) == 1:
+        player_to_update = complement_set_player_claim_weapon[0]
+        playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_weapon)
+    elif len(complement_set_player_claim_weapon) == 2:
+        player_to_update = complement_set_player_claim_weapon
+        for i in player_to_update:
+            playerHashmap[i].update_weapon_possibly_have(claim_weapon, 1/2)
+    else: # len(complement_set_player_claim_weapon) == 3:
+        for i in potential_players:
+            playerHashmap[i].update_weapon_possibly_have(claim_weapon, 1/3)
+
+    ## deal with room, check how many among the 3 potential got claim_room in must-not-have
+    player_with_claim_room_in_must_not_have = get_potential_must_not_have_helper(claim_room, playerHashmap, potential_players)
+    complement_set_player_claim_room = [x for x in potential_players if x not in player_with_claim_room_in_must_not_have]
+    if len(complement_set_player_claim_room) == 1:
+        player_to_update = complement_set_player_claim_room[0]
+        playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_room)
+    elif len(complement_set_player_claim_room) == 2:
+        player_to_update = complement_set_player_claim_room
+        for i in player_to_update:
+            playerHashmap[i].update_room_possibly_have(claim_room, 1/2)
+    else: # len(complement_set_player_claim_room) == 3:
+        for i in potential_players:
+            playerHashmap[i].update_room_possibly_have(claim_room, 1/3)
         
 
 # ========

--- a/src/utils/agentAIUtils.py
+++ b/src/utils/agentAIUtils.py
@@ -354,8 +354,12 @@ def first_True(array):
         idx += 1
 
 
-def otherAgent_turnUpdate_1cardsCase(claimer, claim_suspect, claim_weapon, claim_room, card_giver, playerHashmap):
-    potential_players = {"secret", claimer, card_giver[0]}
+
+def otherAgent_turnUpdate_OneTwo_cardsCase(claimer, claim_suspect, claim_weapon, claim_room, card_giver, playerHashmap, one_or_two):
+    if one_or_two == "one":
+        potential_players = {"secret", claimer, card_giver[0]}
+    else: # one_or_two == "two"
+        potential_players = {"secret", claimer, card_giver[0], card_giver[1]}
     ## check how many of claim objects are in must-have
     player_must_have_claim_suspect = search_in_must_have(playerHashmap, claim_suspect, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
     player_must_have_claim_weapon = search_in_must_have(playerHashmap, claim_weapon, LIST_SUSPECT, LIST_WEAPON, LIST_ROOM)
@@ -370,53 +374,44 @@ def otherAgent_turnUpdate_1cardsCase(claimer, claim_suspect, claim_weapon, claim
     ## deal with suspect, check how many among the 3 potential got claim_suspect in must-not-have
     player_with_claim_suspect_in_must_not_have = get_potential_must_not_have_helper(claim_suspect, playerHashmap, potential_players)
     complement_set_player_claim_suspect = [x for x in potential_players if x not in player_with_claim_suspect_in_must_not_have and x != player_must_have_claim_suspect]
-    if len(complement_set_player_claim_suspect) == 1:
+    length_complement_set = len(complement_set_player_claim_suspect)
+    if length_complement_set == 1:
         player_to_update = complement_set_player_claim_suspect[0]
         playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_suspect)
-    elif len(complement_set_player_claim_suspect) == 2:
-        player_to_update = complement_set_player_claim_suspect
-        for i in player_to_update:
-            playerHashmap[i].update_suspect_possibly_have(claim_suspect, 1/2)
-    elif len(complement_set_player_claim_suspect) == 3:
-        for i in potential_players:
-            playerHashmap[i].update_suspect_possibly_have(claim_suspect, 1/3)
+    elif length_complement_set >= 2 and length_complement_set <=4:
+        for i in complement_set_player_claim_suspect:
+            playerHashmap[i].update_suspect_possibly_have(claim_suspect, 1/length_complement_set)
     else: #len(complement_set_player_claim_suspect) == 0
         pass
     
     ## deal with weapon, check how many among the 3 potential got claim_weapon in must-not-have
     player_with_claim_weapon_in_must_not_have = get_potential_must_not_have_helper(claim_weapon, playerHashmap, potential_players)
     complement_set_player_claim_weapon = [x for x in potential_players if x not in player_with_claim_weapon_in_must_not_have and x != player_must_have_claim_weapon]
+    length_complement_set = len(complement_set_player_claim_weapon)
     # print("potential player: ",potential_players)
     # print("player_with_claim_weapon_in_must_not_have: ",player_with_claim_weapon_in_must_not_have)
     # print("player_must_have_claim_weapon: ",player_must_have_claim_weapon)
     # print("len(complement_set_player_claim_weapon): ", len(complement_set_player_claim_weapon))
     # print("complement_set_player_claim_weapon: ", complement_set_player_claim_weapon)
-    if len(complement_set_player_claim_weapon) == 1:
+    if length_complement_set == 1:
         player_to_update = complement_set_player_claim_weapon[0]
         playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_weapon)
-    elif len(complement_set_player_claim_weapon) == 2:
-        player_to_update = complement_set_player_claim_weapon
-        for i in player_to_update:
-            playerHashmap[i].update_weapon_possibly_have(claim_weapon, 1/2)
-    elif len(complement_set_player_claim_weapon) == 3:
-        for i in potential_players:
-            playerHashmap[i].update_weapon_possibly_have(claim_weapon, 1/3)
+    elif length_complement_set >= 2 and length_complement_set <= 4:
+        for i in complement_set_player_claim_weapon:
+            playerHashmap[i].update_weapon_possibly_have(claim_weapon, 1/length_complement_set)
     else: #len(complement_set_player_claim_weapon) == 0
         pass 
 
     ## deal with room, check how many among the 3 potential got claim_room in must-not-have
     player_with_claim_room_in_must_not_have = get_potential_must_not_have_helper(claim_room, playerHashmap, potential_players)
     complement_set_player_claim_room = [x for x in potential_players if x not in player_with_claim_room_in_must_not_have and x != player_must_have_claim_room]
-    if len(complement_set_player_claim_room) == 1:
+    length_complement_set = len(complement_set_player_claim_room)
+    if length_complement_set == 1:
         player_to_update = complement_set_player_claim_room[0]
         playerHashmap[player_to_update].move_ele_possibly_to_must_have(claim_room)
-    elif len(complement_set_player_claim_room) == 2:
-        player_to_update = complement_set_player_claim_room
-        for i in player_to_update:
-            playerHashmap[i].update_room_possibly_have(claim_room, 1/2)
-    elif len(complement_set_player_claim_room) == 3:
-        for i in potential_players:
-            playerHashmap[i].update_room_possibly_have(claim_room, 1/3)
+    elif length_complement_set >= 2 and length_complement_set <= 4:
+        for i in complement_set_player_claim_room:
+            playerHashmap[i].update_room_possibly_have(claim_room, 1/length_complement_set)
     else: #len(complement_set_player_claim_room) == 0
         pass
         


### PR DESCRIPTION
## Description
Add the methods for inference and score updates when there it's other players turn, and the cases when 0,1,2,3 cardgivers are presented. 

Also, fix a few bugs and made improvements to secret rebalance and inference method. 

## Test
Add a few unittest to verify the performance of the agent, all test past. 